### PR TITLE
Add option to limit the number of overlapping perimeters

### DIFF
--- a/resources/ui_layout/print.ui
+++ b/resources/ui_layout/print.ui
@@ -29,7 +29,10 @@ group:Quality
 		setting:label$:avoid_crossing_perimeters
 		setting:label$not on first layer:avoid_crossing_not_first_layer
 	end_line
-	setting:thin_perimeters
+	line:Overlapping external perimeter
+		setting:label$:thin_perimeters
+		setting:label$also for all perimeters:thin_perimeters_all
+	end_line
 	line:Thin walls
 		setting:thin_walls
 		setting:width$5:thin_walls_min_width

--- a/src/libslic3r/Layer.cpp
+++ b/src/libslic3r/Layer.cpp
@@ -165,6 +165,7 @@ void Layer::make_perimeters()
                 && config.thin_walls_min_width      == other_config.thin_walls_min_width
                 && config.thin_walls_overlap        == other_config.thin_walls_overlap
                 && config.thin_perimeters           == other_config.thin_perimeters
+                && config.thin_perimeters_all       == other_config.thin_perimeters_all
                 && config.infill_overlap            == other_config.infill_overlap
                 && config.perimeter_loop            == other_config.perimeter_loop) {
                 layerms.push_back(other_layerm);

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -409,6 +409,9 @@ void PerimeterGenerator::process()
                     }
                 }
 
+                // allow this perimeter to overlap itself?
+                bool thin_perimeter = this->config->thin_perimeters && (i == 0 || this->config->thin_perimeters_all);
+
                 // Calculate next onion shell of perimeters.
                 //this variable stored the next onion
                 ExPolygons next_onion;
@@ -416,7 +419,7 @@ void PerimeterGenerator::process()
                     // compute next onion
                         // the minimum thickness of a single loop is:
                         // ext_width/2 + ext_spacing/2 + spacing/2 + width/2
-                    if (this->config->thin_perimeters)
+                    if (thin_perimeter)
                         next_onion = offset_ex(
                             last,
                             -(float)(ext_perimeter_width / 2));
@@ -496,10 +499,7 @@ void PerimeterGenerator::process()
                         // it's a bit like re-add thin area in to perimeter area.
                         // it can over-extrude a bit, but it's for a better good.
                         {
-
-
-
-                            if(config->thin_perimeters)
+                            if (thin_perimeter)
                                 next_onion = union_ex(next_onion, offset_ex(diff_ex(last, thins, true),
                                     -(float)(ext_perimeter_width / 2)));
                             else
@@ -512,7 +512,7 @@ void PerimeterGenerator::process()
                     //FIXME Is this offset correct if the line width of the inner perimeters differs
                     // from the line width of the infill?
                     coord_t good_spacing = (i == 1) ? ext_perimeter_spacing2 : perimeter_spacing;
-                    if (!this->config->thin_perimeters){
+                    if (!thin_perimeter) {
                         // This path will ensure, that the perimeters do not overfill, as in 
                         // prusa3d/Slic3r GH #32, but with the cost of rounding the perimeters
                         // excessively, creating gaps, which then need to be filled in by the not very 

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -3130,12 +3130,20 @@ void PrintConfigDef::init_fff_params()
     def->set_default_value(new ConfigOptionInts { 200 });
 
     def = this->add("thin_perimeters", coBool);
-    def->label = L("Overlapping perimeters");
-    def->full_label = L("Overlapping perimeters");
+    def->label = L("Overlapping external perimeter");
+    def->full_label = L("Overlapping external perimeter");
     def->category = OptionCategory::perimeter;
-    def->tooltip = L("Allow external perimeter to overlap each other to avoid the use of thin walls. Note that their flow isn't adjusted and so it will result in over-extruding and undefined behavior.");
+    def->tooltip = L("Allow outermost perimeter to overlap itself to avoid the use of thin walls. Note that their flow isn't adjusted and so it will result in over-extruding and undefined behavior.");
     def->mode = comExpert;
     def->set_default_value(new ConfigOptionBool(true));
+
+    def = this->add("thin_perimeters_all", coBool);
+    def->label = L("Overlapping all perimeters");
+    def->full_label = L("Overlapping all perimeters");
+    def->category = OptionCategory::perimeter;
+    def->tooltip = L("Allow all perimeters to overlap, instead of just external ones.");
+    def->mode = comExpert;
+    def->set_default_value(new ConfigOptionBool(false));
 
     def = this->add("thin_walls", coBool);
     def->label = L("");

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -685,6 +685,7 @@ public:
     ConfigOptionFloatOrPercent      solid_infill_speed;
     // Detect thin walls.
     ConfigOptionBool                thin_perimeters;
+    ConfigOptionBool                thin_perimeters_all;
     ConfigOptionBool                thin_walls;
     ConfigOptionFloatOrPercent      thin_walls_min_width;
     ConfigOptionFloatOrPercent      thin_walls_overlap;
@@ -769,6 +770,7 @@ protected:
         OPT_PTR(solid_infill_every_layers);
         OPT_PTR(solid_infill_speed);
         OPT_PTR(thin_perimeters);
+        OPT_PTR(thin_perimeters_all);
         OPT_PTR(thin_walls);
         OPT_PTR(thin_walls_min_width);
         OPT_PTR(thin_walls_overlap);

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -304,6 +304,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
     toggle_field("overhangs_width", config->opt_bool("overhangs"));
     toggle_field("overhangs_reverse_threshold", config->opt_bool("overhangs_reverse"));
     toggle_field("min_width_top_surface", config->opt_bool("only_one_perimeter_top"));
+    toggle_field("thin_perimeters_all", config->opt_bool("thin_perimeters"));
 
     for (auto el : { "external_perimeters_vase", "external_perimeters_nothole", "external_perimeters_hole", "perimeter_bonding"})
         toggle_field(el, config->opt_bool("external_perimeters_first"));

--- a/src/slic3r/GUI/Preset.cpp
+++ b/src/slic3r/GUI/Preset.cpp
@@ -438,7 +438,7 @@ const std::vector<std::string>& Preset::print_options()
         "allow_empty_layers",
         "avoid_crossing_perimeters", 
         "avoid_crossing_not_first_layer",
-        "thin_perimeters",
+        "thin_perimeters", "thin_perimeters_all",
         "thin_walls", "overhangs", 
         "overhangs_width",
         "overhangs_reverse",


### PR DESCRIPTION
In general we don't like overlapping perimeters, but occasionally it is useful to allow the outermost perimeter to overlap, so that we have one continuous extrusion around the part, improving edge quality and layer adhesion. This PR adds an "overlapping perimeters count" option, to allow only the outermost *n* perimeters to overlap themselves.

Motivating example
----
([STL here](https://github.com/VoronDesign/Voron-0/blob/7ef301b8c9762fcdea52bcf256fc1fd6d5d09232/VORON-0/STLs/VORON0.0/Dragon_Toolhead/Toolhead_Right_Dragon_x1.STL), 0.2 layers, 0.44 extrusion widths, 4 perimeters, first layer):
![image](https://user-images.githubusercontent.com/2345921/90285380-a6fedc80-de28-11ea-94b4-fa24ba3b6580.png)


The lower left part has "overlapping perimeters" enabled (for all perimeters). This results in a single thick line in the circled area disconnected from the rest of the part (despite having thin_walls_merge enabled). This print failed due to insufficient adhesion of this line to the bed and rest of the part.

The lower right part has "overlapping perimeters" disabled. This printed okay but the thin wall in the circled area is overextruded due to the overlap, which is undesirable.

The top part has the new "overlapping perimeters count" set to 1, and the result has neither of the bad features of the other two. This is automatic and could not have been achieved by adding a modifier to only allow overlap in a certain region, since that would have split the layer into two regions with their own perimeters.

Another example
----

([STL here](https://github.com/VoronDesign/Voron-0/blob/7ef301b8c9762fcdea52bcf256fc1fd6d5d09232/VORON-0/STLs/VORON0.0/T8_Nut_Block_x1.STL), same settings as above, first layer):
![image](https://user-images.githubusercontent.com/2345921/90221145-7b470c80-ddbe-11ea-909d-e1f7ea82d6db.png)

Same layout as the previous example. The lower left with "overlapping perimeters" enabled shows overextrusion in several places; it also leaves very thin gaps due to the large curvature in the overlap (which aren't filled with gap_fill_min_area = 100%). The lower right with "overlapping perimeters" disabled shows a thin wall (circled area), which leaves a visible blob on the outside of the part when printed. The top (only overlapping the outermost perimeter) has neither of these problems.

Questions
----
* I'm not convinced that it is useful to set this setting to more than 1, since the gap fill resulting from disabling overlap non-external perimeters would be anchored on some perimeters during the print. So, I wasn't sure whether this should just be a boolean option? For now this errs on the side of more choice.
* I'm not sure about the "limit" label in the print settings UI, so perhaps there is a clearer label for this option?