### PR TITLE
Add missing header for boost::algorithm::to_upper_copy

### DIFF
--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -25,6 +25,8 @@ TODO LIST
 #include "BoundingBox.hpp"
 #include "Flow.hpp"
 
+#include <boost/algorithm/string/case_conv.hpp>
+
 #if defined(__linux) || defined(__GNUC__ )
 #include <strings.h>
 #endif /* __linux */


### PR DESCRIPTION
Had a build failure due to a missing declaration for boost::algorithm::to_upper_copy