### PR TITLE
Update GCode.cpp - Fix object_center "-nan"

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -1330,7 +1330,7 @@ void GCode::_do_export(Print &print, FILE *file)
                 BoundingBoxf3 m_bounding_box = print_instance.model_instance->transform_bounding_box(raw_bbox);
                 _write_format(file, "; object:{\"name\":\"%s\",\"id\":\"%s id:%d copy %d\",\"object_center\":[%f,%f,%f],\"boundingbox_center\":[%f,%f,%f],\"boundingbox_size\":[%f,%f,%f]}\n",
                     object_name.c_str(), print_object->model_object()->name.c_str(), this->m_ordered_objects.size() - 1, copy_id,
-                    m_bounding_box.center().x(), m_bounding_box.center().y(), 0,
+                    m_bounding_box.center().x(), m_bounding_box.center().y(), 0.0,
                     m_bounding_box.center().x(), m_bounding_box.center().y(), m_bounding_box.center().z(),
                     m_bounding_box.size().x(), m_bounding_box.size().y(), m_bounding_box.size().z()
                 );


### PR DESCRIPTION
One small error and whole slicing in octoprint was broken.
Plugin OctoPrint Cancelobject is using json.loads to obtain object's center and it was broken because of **-nan** instead of **0**

Before:
`; object:{"name":"cube","id":"cube.stl id:0 copy 0","object_center":[117.500000,117.500000,-nan],"boundingbox_center":[117.500000,117.500000,12.500000],"boundingbox_size":[25.000000,25.000000,25.000000]}`
after:
`; object:{"name":"cube","id":"cube.stl id:0 copy 0","object_center":[117.500000,117.500000,0.000000],"boundingbox_center":[117.500000,117.500000,12.500000],"boundingbox_size":[25.000000,25.000000,25.000000]}`

Trust me, whole day lost because of that 😢 