### PR TITLE
Fix typo in Creality.ini

### DIFF
--- a/resources/profiles/Creality.ini
+++ b/resources/profiles/Creality.ini
@@ -286,7 +286,7 @@ solid_infill_extrusion_width = 110%
 top_infill_extrusion_width = 100%
 support_material_extrusion_width = 95%
 
-[print:*0.8mm*]
+[print:*0.08mm*]
 inherits = *common*
 layer_height = 0.08
 perimeters = 3
@@ -333,8 +333,8 @@ top_infill_extrusion_width = 0.45
 bottom_solid_layers = 3
 top_solid_layers = 4
 
-[print:0.8mm HIGHDETAIL @CREALITY]
-inherits = *0.8mm*
+[print:0.08mm HIGHDETAIL @CREALITY]
+inherits = *0.08mm*
 compatible_printers_condition = printer_model=~/(ENDER|CR).*/ and nozzle_diameter[0]==0.4
 
 [print:0.12mm DETAIL @CREALITY]


### PR DESCRIPTION
Fix typo so that configuration name (=print:0.08mm HIGHDETAIL @CREALITY) matches configuration (layer_height = 0.08)