### PR TITLE
Ignore DS_Store files in MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ xs/assertlib*
 local-lib
 build*
 deps/deps-*
+
+# MacOS Ignores
+.DS_Store


### PR DESCRIPTION
These files don't need to be kept under configuration management. And when cloning a project on a Mac, they will be created very quickly.