### PR TITLE
Issue 1238: Unsaved changes dialog displays incorrect GCode Flavor

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -2688,11 +2688,13 @@ void PrintConfigDef::init_fff_params()
     def->enum_values.push_back("flashair");
     def->enum_values.push_back("astrobox");
     def->enum_values.push_back("repetier");
+    def->enum_values.push_back("klipper");
     def->enum_labels.push_back("OctoPrint");
     def->enum_labels.push_back("Duet");
     def->enum_labels.push_back("FlashAir");
     def->enum_labels.push_back("AstroBox");
     def->enum_labels.push_back("Repetier");
+    def->enum_labels.push_back("Klipper");
     def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionEnum<PrintHostType>(htOctoPrint));
 

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -72,7 +72,12 @@ enum class MachineLimitsUsage : uint8_t {
 };
 
 enum PrintHostType {
-    htOctoPrint, htDuet, htFlashAir, htAstroBox, htRepetier
+    htOctoPrint,
+    htDuet,
+    htFlashAir,
+    htAstroBox,
+    htRepetier,
+    htKlipper,
 };
 
 enum AuthorizationType {
@@ -222,6 +227,7 @@ template<> inline const t_config_enum_values& ConfigOptionEnum<PrintHostType>::g
         {"flashair", htFlashAir},
         {"astrobox", htAstroBox},
         {"repetier", htRepetier},
+        {"klipper", htKlipper},
     };
     return keys_map;
 }

--- a/src/slic3r/CMakeLists.txt
+++ b/src/slic3r/CMakeLists.txt
@@ -215,6 +215,8 @@ set(SLIC3R_GUI_SOURCES
     Utils/FixModelByWin10.hpp
     Utils/OctoPrint.cpp
     Utils/OctoPrint.hpp
+    Utils/Klipper.cpp
+    Utils/Klipper.hpp
     Utils/Duet.cpp
     Utils/Duet.hpp
     Utils/FlashAir.cpp

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -496,10 +496,15 @@ void PhysicalPrinterDialog::update()
         m_optgroup->hide_field("printhost_authorization_type");
         m_optgroup->show_field("printhost_apikey", true);
         for (const std::string& opt_key : std::vector<std::string>{ "printhost_user", "printhost_password" })
-            m_optgroup->hide_field(opt_key);
+            m_optgroup->hide_field(opt_key);        
         const auto opt = m_config->option<ConfigOptionEnum<PrintHostType>>("host_type");
         supports_multiple_printers = opt && opt->value == htRepetier;
-    }
+
+        // hide api key for klipper
+        if (opt && opt->value == htKlipper) {
+            m_optgroup->hide_field("printhost_apikey");
+        }
+   }
     else {
         m_optgroup->set_value("host_type", int(PrintHostType::htOctoPrint), false);
         m_optgroup->hide_field("host_type");

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -838,25 +838,20 @@ bool UnsavedChangesDialog::save(PresetCollection* dependent_presets)
 }
 
 template<class T>
-wxString get_string_from_enum(const std::string& opt_key, const DynamicPrintConfig& config, bool is_infill = false)
+wxString get_string_from_enum(const std::string& opt_key, const DynamicPrintConfig& config)
 {
     const ConfigOptionDef& def = config.def()->options.at(opt_key);
     const std::vector<std::string>& names = def.enum_labels;//ConfigOptionEnum<T>::get_enum_names();
     T val = config.option<ConfigOptionEnum<T>>(opt_key)->value;
 
-    // Each infill doesn't use all list of infill declared in PrintConfig.hpp.
-    // So we should "convert" val to the correct one
-    if (is_infill) {
-        for (auto key_val : *def.enum_keys_map)
-            if ((int)key_val.second == (int)val) {
-                auto it = std::find(def.enum_values.begin(), def.enum_values.end(), key_val.first);
-                if (it == def.enum_values.end())
-                    return "";
-                return from_u8(_utf8(names[it - def.enum_values.begin()]));
-            }
-        return _L("Undef");
-    }
-    return from_u8(_utf8(names[static_cast<int>(val)]));
+    for (auto key_val : *def.enum_keys_map)
+        if ((int)key_val.second == (int)val) {
+            auto it = std::find(def.enum_values.begin(), def.enum_values.end(), key_val.first);
+            if (it == def.enum_values.end())
+                return "";
+            return from_u8(_utf8(names[it - def.enum_values.begin()]));
+        }
+    return _L("Undef");
 }
 
 static int get_id_from_opt_key(std::string opt_key)
@@ -954,7 +949,7 @@ static wxString get_string_value(std::string opt_key, const DynamicPrintConfig& 
             opt_key == "solid_fill_pattern" ||
             opt_key == "brim_ears_pattern" ||
             opt_key == "support_material_interface_pattern")
-            return get_string_from_enum<InfillPattern>(opt_key, config, true);
+            return get_string_from_enum<InfillPattern>(opt_key, config);
         if (opt_key == "complete_objects_sort")
             return get_string_from_enum<CompleteObjectSort>(opt_key, config);
         if (opt_key == "display_orientation")
@@ -977,7 +972,7 @@ static wxString get_string_value(std::string opt_key, const DynamicPrintConfig& 
         if (opt_key == "no_perimeter_unsupported_algo")
             return get_string_from_enum<NoPerimeterUnsupportedAlgo>(opt_key, config);
         if (opt_key == "perimeter_loop_seam")
-            return get_string_from_enum<SeamPosition>(opt_key, config, true);
+            return get_string_from_enum<SeamPosition>(opt_key, config);
         if (opt_key == "printhost_authorization_type")
             return get_string_from_enum<AuthorizationType>(opt_key, config);
         if (opt_key == "seam_position")

--- a/src/slic3r/Utils/Klipper.cpp
+++ b/src/slic3r/Utils/Klipper.cpp
@@ -1,0 +1,30 @@
+#include "Klipper.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <exception>
+#include <boost/format.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <wx/progdlg.h>
+#include <wx/string.h>
+
+#include "slic3r/GUI/I18N.hpp"
+#include "slic3r/GUI/GUI.hpp"
+#include "Http.hpp"
+
+
+namespace fs = boost::filesystem;
+namespace pt = boost::property_tree;
+
+
+namespace Slic3r {
+
+Klipper::Klipper(DynamicPrintConfig *config) : OctoPrint(config) {}
+
+const char* Klipper::get_name() const { return "Klipper"; }
+
+}

--- a/src/slic3r/Utils/Klipper.hpp
+++ b/src/slic3r/Utils/Klipper.hpp
@@ -1,16 +1,7 @@
 #ifndef slic3r_Klipper_hpp_
 #define slic3r_Klipper_hpp_
 
-#include <boost/algorithm/string.hpp>
-
-#include <string>
-#include <wx/string.h>
-#include <wx/arrstr.h>
-#include <boost/optional.hpp>
-
 #include "OctoPrint.hpp"
-#include "libslic3r/PrintConfig.hpp"
-
 
 namespace Slic3r {
 

--- a/src/slic3r/Utils/Klipper.hpp
+++ b/src/slic3r/Utils/Klipper.hpp
@@ -1,0 +1,30 @@
+#ifndef slic3r_Klipper_hpp_
+#define slic3r_Klipper_hpp_
+
+#include <boost/algorithm/string.hpp>
+
+#include <string>
+#include <wx/string.h>
+#include <wx/arrstr.h>
+#include <boost/optional.hpp>
+
+#include "OctoPrint.hpp"
+#include "libslic3r/PrintConfig.hpp"
+
+
+namespace Slic3r {
+
+class DynamicPrintConfig;
+
+class Klipper : public OctoPrint
+{
+public:
+    Klipper(DynamicPrintConfig *config);
+    ~Klipper() override = default;
+
+    const char* get_name() const;
+};
+
+}
+
+#endif

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -85,10 +85,7 @@ wxString OctoPrint::get_test_ok_msg () const
 
 wxString OctoPrint::get_test_failed_msg (wxString &msg) const
 {
-    return GUI::from_u8((boost::format("%s: %s\n\n%s")
-        % _utf8(L("Could not connect to OctoPrint"))
-        % std::string(msg.ToUTF8())
-        % _utf8(L("Note: OctoPrint version at least 1.1.0 is required."))).str());
+    return wxString::Format("%s: %s\n\n%s", wxString::Format(_(L("Could not connect to %s")), get_name()), msg, _(L("Note: OctoPrint version at least 1.1.0 is required.")));
 }
 
 bool OctoPrint::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, ErrorFn error_fn) const

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -80,7 +80,7 @@ bool OctoPrint::test(wxString &msg) const
 
 wxString OctoPrint::get_test_ok_msg () const
 {
-    return _(L("Connection to OctoPrint works correctly."));
+    return wxString::Format(_(L("Connection to %s works correctly.")), get_name());
 }
 
 wxString OctoPrint::get_test_failed_msg (wxString &msg) const
@@ -133,7 +133,7 @@ bool OctoPrint::upload(PrintHostUpload upload_data, ProgressFn prorgess_fn, Erro
             prorgess_fn(std::move(progress), cancel);
             if (cancel) {
                 // Upload was canceled
-                BOOST_LOG_TRIVIAL(info) << "Octoprint: Upload canceled";
+                BOOST_LOG_TRIVIAL(info) << get_name() << ": Upload canceled";
                 res = false;
             }
         })

--- a/src/slic3r/Utils/PrintHost.cpp
+++ b/src/slic3r/Utils/PrintHost.cpp
@@ -18,6 +18,7 @@
 #include "FlashAir.hpp"
 #include "AstroBox.hpp"
 #include "Repetier.hpp"
+#include "Klipper.hpp"
 #include "../GUI/PrintHostDialogs.hpp"
 
 namespace fs = boost::filesystem;
@@ -50,6 +51,7 @@ PrintHost* PrintHost::get_print_host(DynamicPrintConfig *config)
             case htFlashAir:  return new FlashAir(config);
             case htAstroBox:  return new AstroBox(config);
             case htRepetier:  return new Repetier(config);
+            case htKlipper:   return new Klipper(config);
             default:          return nullptr;
         }
     } else {


### PR DESCRIPTION
The order in which enums are added to the 2 vectors is not guarenteed to be in numerical order.
Thus always look up the values and labels by key and not by the enum's int value.