### PR TITLE
For review - Remove trailing zeros from gcode feed rates.

### DIFF
--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -614,7 +614,7 @@ std::string GCodeWriter::_retract(double length, double restart_extra, const std
                 gcode << "G10 ; retract\n";
         } else {
             gcode << "G1 " << m_extrusion_axis << E_NUM(m_tool->E())
-                           << " F" << F_NUM(m_tool->retract_speed() * 60.);
+                           << " F" << m_tool->retract_speed();
             COMMENT(comment);
             gcode << "\n";
         }
@@ -646,7 +646,7 @@ std::string GCodeWriter::unretract()
         } else {
             // use G1 instead of G0 because G0 will blend the restart with the previous travel move
             gcode << "G1 " << m_extrusion_axis << E_NUM(m_tool->E())
-                           << " F" << F_NUM(m_tool->deretract_speed() * 60.);
+                           << " F" << m_tool->deretract_speed();
             if (this->config.gcode_comments) gcode << " ; unretract";
             gcode << "\n";
         }

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -614,7 +614,7 @@ std::string GCodeWriter::_retract(double length, double restart_extra, const std
                 gcode << "G10 ; retract\n";
         } else {
             gcode << "G1 " << m_extrusion_axis << E_NUM(m_tool->E())
-                           << " F" << m_tool->retract_speed();
+                           << " F" << m_tool->retract_speed() * 60;
             COMMENT(comment);
             gcode << "\n";
         }
@@ -646,7 +646,7 @@ std::string GCodeWriter::unretract()
         } else {
             // use G1 instead of G0 because G0 will blend the restart with the previous travel move
             gcode << "G1 " << m_extrusion_axis << E_NUM(m_tool->E())
-                           << " F" << m_tool->deretract_speed();
+                           << " F" << m_tool->deretract_speed() * 60;
             if (this->config.gcode_comments) gcode << " ; unretract";
             gcode << "\n";
         }

--- a/tests/fff_print/test_gcodewriter.cpp
+++ b/tests/fff_print/test_gcodewriter.cpp
@@ -68,28 +68,28 @@ SCENARIO("lift() is not ignored after unlift() at normal values of Z", "[GCodeWr
     }
 }
 
-SCENARIO("set_speed emits values with fixed-point output.", "[GCodeWriter]") {
+SCENARIO("set_speed emits values with floating-point output, 8 significant digits.", "[GCodeWriter]") {
 
     GIVEN("GCodeWriter instance") {
         GCodeWriter writer;
-        WHEN("set_speed is called to set speed to 99999.123") {
-            THEN("Output string is G1 F99999.123") {
-                REQUIRE_THAT(writer.set_speed(99999.123), Catch::Equals("G1 F99999.123\n"));
+        WHEN("set_speed is called to set speed to 12345.678") {
+            THEN("Output string is G1 12345.678") {
+                REQUIRE_THAT(writer.set_speed(12345.678), Catch::Equals("G1 F12345.678\n"));
             }
         }
         WHEN("set_speed is called to set speed to 1") {
-            THEN("Output string is G1 F1.000") {
-                REQUIRE_THAT(writer.set_speed(1.0), Catch::Equals("G1 F1.000\n"));
+            THEN("Output string is G1 F1") {
+                REQUIRE_THAT(writer.set_speed(1.0), Catch::Equals("G1 F1\n"));
             }
         }
-        WHEN("set_speed is called to set speed to 203.200022") {
-            THEN("Output string is G1 F203.200") {
-                REQUIRE_THAT(writer.set_speed(203.200022), Catch::Equals("G1 F203.200\n"));
+        WHEN("set_speed is called to set speed to 203.2000022") {
+            THEN("Output string is G1 F203.2") {
+                REQUIRE_THAT(writer.set_speed(203.2000022), Catch::Equals("G1 F203.2\n"));
             }
         }
-        WHEN("set_speed is called to set speed to 203.200522") {
-            THEN("Output string is G1 F203.201") {
-                REQUIRE_THAT(writer.set_speed(203.200522), Catch::Equals("G1 F203.201\n"));
+        WHEN("set_speed is called to set speed to 12345.200522") {
+            THEN("Output string is G1 F12345.201") {
+                REQUIRE_THAT(writer.set_speed(12345.200522), Catch::Equals("G1 F12345.201\n"));
             }
         }
     }


### PR DESCRIPTION
Changed the format of feed rates from fixed point with 3 decimal places to floating point with 8 digits of precision. This means the decimal places are retained when necessary and omitted when not required. So

`G1 X16.288 Y28.463 F3600.000` is written out as `G1 X16.288 Y28.463 F3600`

whereas

`G1 X16.288 Y28.463 F3600.123` is written out as `G1 X16.288 Y28.463 F3600.123`

This makes the GCODE more readable and results in a small saving in GCODE file size (about 1%, or 20KB in a 2MB file).
