### PR TITLE
README: point discord link to a particular comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 
-[![you can get this shield at shields.io](https://img.shields.io/discord/771316156203270154?color=7289da&logo=discord&logoColor=white)](https://discord.gg/ygBBdRRwJY)
-
+[![you can get this shield at shields.io](https://img.shields.io/discord/771316156203270154?color=7289da&logo=discord&logoColor=white)](https://github.com/supermerill/SuperSlicer/issues/611#issuecomment-907833287)
 # SuperSlicer
 
 **A PrusaSlicer fork (which is a slic3r fork)** (previously Slic3r++)


### PR DESCRIPTION
Right now, discord shield points to a non-functional link. This makes it easier to find a working one