### PR TITLE
Add preference to disable changing focus due to mouse movement

### DIFF
--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -166,6 +166,9 @@ void AppConfig::set_defaults()
         if (get("suppress_hyperlinks").empty())
             set("suppress_hyperlinks", "1");
 
+        if (get("focus_platter_on_mouse").empty())
+            set("focus_platter_on_mouse", "1");
+
         if (get("custom_toolbar_size").empty())
             set("custom_toolbar_size", "100");
 

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3225,9 +3225,9 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
     }
 
     if (m_gizmos.on_mouse(evt)) {
-        if (wxWindow::FindFocus() != this->m_canvas)
+        //if (wxWindow::FindFocus() != this->m_canvas)
             // Grab keyboard focus for input in gizmo dialogs.
-            m_canvas->SetFocus();
+            //m_canvas->SetFocus();
 
         if (evt.LeftUp() || evt.MiddleUp() || evt.RightUp())
             mouse_up_cleanup();
@@ -3262,8 +3262,8 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
             while (p->GetParent())
                 p = p->GetParent();
             auto *top_level_wnd = dynamic_cast<wxTopLevelWindow*>(p);
-            if (top_level_wnd && top_level_wnd->IsActive())
-                m_canvas->SetFocus();
+            //if (top_level_wnd && top_level_wnd->IsActive())
+                //m_canvas->SetFocus();
             m_mouse.position = pos.cast<double>();
             m_tooltip_enabled = false;
             // 1) forces a frame render to ensure that m_hover_volume_idxs is updated even when the user right clicks while

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3267,9 +3267,6 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
                 p = p->GetParent();
             auto *top_level_wnd = dynamic_cast<wxTopLevelWindow*>(p);
             if (focus_platter_on_mouse) {
-                if (wxWindow::FindFocus() != this->m_canvas)
-                    // Grab keyboard focus for input in gizmo dialogs.
-                    m_canvas->SetFocus();
                 if (top_level_wnd && top_level_wnd->IsActive())
                     m_canvas->SetFocus();
             }

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3224,10 +3224,14 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
         return;
     }
 
+    auto* app_config = GUI::wxGetApp().app_config;
+    bool focus_platter_on_mouse = app_config->get("focus_platter_on_mouse") == "1";
     if (m_gizmos.on_mouse(evt)) {
-        //if (wxWindow::FindFocus() != this->m_canvas)
-            // Grab keyboard focus for input in gizmo dialogs.
-            //m_canvas->SetFocus();
+        if (focus_platter_on_mouse) {
+            if (wxWindow::FindFocus() != this->m_canvas)
+                // Grab keyboard focus for input in gizmo dialogs.
+                m_canvas->SetFocus();
+        }
 
         if (evt.LeftUp() || evt.MiddleUp() || evt.RightUp())
             mouse_up_cleanup();
@@ -3262,8 +3266,13 @@ void GLCanvas3D::on_mouse(wxMouseEvent& evt)
             while (p->GetParent())
                 p = p->GetParent();
             auto *top_level_wnd = dynamic_cast<wxTopLevelWindow*>(p);
-            //if (top_level_wnd && top_level_wnd->IsActive())
-                //m_canvas->SetFocus();
+            if (focus_platter_on_mouse) {
+                if (wxWindow::FindFocus() != this->m_canvas)
+                    // Grab keyboard focus for input in gizmo dialogs.
+                    m_canvas->SetFocus();
+                if (top_level_wnd && top_level_wnd->IsActive())
+                    m_canvas->SetFocus();
+            }
             m_mouse.position = pos.cast<double>();
             m_tooltip_enabled = false;
             // 1) forces a frame render to ensure that m_hover_volume_idxs is updated even when the user right clicks while

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -450,6 +450,14 @@ void PreferencesDialog::build()
 		option = Option(def, "suppress_hyperlinks");
 		m_optgroups_gui.back()->append_single_option_line(option);
 
+		def.label = L("Focusing platter on mouse over");
+		def.type = coBool;
+		def.tooltip = L("If disabled, moving the mouse over the platter panel will not change the focus. "
+			"If enabled, moving the mouse over the platter panel will move focus there, and away from the current control.");
+		def.set_default_value(new ConfigOptionBool{ app_config->get("focus_platter_on_mouse") == "1" });
+		option = Option(def, "focus_platter_on_mouse");
+		m_optgroups_gui.back()->append_single_option_line(option);
+
 		activate_options_tab(m_optgroups_gui.back(), 3);
 		m_optgroups_gui.emplace_back(create_gui_options_group(_L("Appearance"), tabs));
 


### PR DESCRIPTION
A longstanding irritant to me has been if I'm editing a value (such
as the model X position) and I move the mouse over the platter, focus
is lost in the input box, and digits and tab behave in unexpected ways.

This is due to the canvas taking focus on mouse movement apparently so
that keyboard shortcuts for the items in the left bar work.  Since I've
never tried to use those keyboard shortcuts, it's more important to me
that the input box I clicked on receives the input I try to enter than
being able to use keyboard shortcuts for something else.

I've been using this change on my local branch for a while now on FreeBSD and haven't encountered any issues, but I have not tested it on Windows or macOS, and upstream appears to place a very high importance on the gizmo shortcuts working.