### PR TITLE
Added test for sysctl path

### DIFF
--- a/src/platform/unix/BuildLinuxImage.sh.in
+++ b/src/platform/unix/BuildLinuxImage.sh.in
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+# Our sysctl call may be run as normal user,
+# but /sbin is not always in normal users' PATH.
+if [[ -f /sbin/sysctl && -x /sbin/sysctl ]]; then sysctl_bin=/sbin/sysctl
+else sysctl_bin=sysctl  # If not found in sbin, hope
+fi
+
 export ROOT=`pwd`
-export NCORES=`sysctl -n hw.ncpu`
+export NCORES=`"$sysctl_bin" -n hw.ncpu`
 
 while getopts ":ih" opt; do
   case ${opt} in


### PR DESCRIPTION
Some distributions don't have /sbin in the user path by default, so sysctl is not found with the plain call without the path.  This patch catches if it exists that specific path (/sbin/sysctl) and otherwise defaults to the prior method of just hoping it's found somewhere.