### PR TITLE
Allow configuration directory next to app bundle on MacOs

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -744,10 +744,18 @@ void GUI_App::init_app_config()
 	// Mac : "~/Library/Application Support/Slic3r"
 
     if (data_dir().empty()) {
-        //check if there is a "configuration" directory next to the resources
+        //check if there is a "configuration" directory...
+#ifdef __APPLE__        
+        //...next to the app bundle on MacOs
+        if (boost::filesystem::exists(boost::filesystem::path{ resources_dir() } / ".." / ".." / ".." / "configuration")) {
+            set_data_dir((boost::filesystem::path{ resources_dir() } / ".." / ".." / ".." / "configuration").string());
+        } else {
+#else           
+        //... next to the resources directory
         if (boost::filesystem::exists(boost::filesystem::path{ resources_dir() } / ".." / "configuration")) {
             set_data_dir((boost::filesystem::path{ resources_dir() } / ".." / "configuration").string());
-        } else {
+        } else { 
+#endif
 #ifndef __linux__
             set_data_dir(wxStandardPaths::Get().GetUserDataDir().ToUTF8().data());
 #else


### PR DESCRIPTION
To use the "portable" feature of SuperSlicer under MacOs one need to create a `configuration` folder within the app bundle under `/SuperSlicer.app/Contents`. That makes it harder to switch to a newer version, because when app bundle is replaced and one forgot to "backup" the `configuration` directory within the bundle, all configurations are lost. Besides that, it is unusual to navigate into app bundles and change contents. 

So within my PR I slightly adopt the code from #1212 to check for MacOs, if there is a `configuration` directory next to the app bundle itself. 

Edit: Sorry for not opening an issue beforehand.