### PR TITLE
Check the return value of get_field() before use

### DIFF
--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -3032,8 +3032,11 @@ void TabPrinter::toggle_options()
         }
 
         // wipe_only_crossing can only work if avoid_crossing_perimeters
-        if (!full_print_config.opt_bool("avoid_crossing_perimeters"))
-            get_field("wipe_only_crossing", i)->toggle(false);
+        if (!full_print_config.opt_bool("avoid_crossing_perimeters")) {
+            field = get_field("wipe_only_crossing", i);
+            if (field)
+                field->toggle(false);
+        }
 
         if (use_firmware_retraction && wipe) {
             wxMessageDialog dialog(parent(),


### PR DESCRIPTION
Other calls to toggle() check if the field exists first,
this one should too.

Fixes #2126

Signed-off-by: Stephen Hurd <shurd@sasktel.net>