### PR TITLE
add "in repo" badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![you can get this shield at shields.io](https://img.shields.io/discord/771316156203270154?color=7289da&logo=discord&logoColor=white)](https://github.com/supermerill/SuperSlicer/issues/611#issuecomment-907833287) [![you can get this shield at shields.io](https://img.shields.io/reddit/subreddit-subscribers/slic3r)](https://reddit.com/r/slic3r) 
+[![you can get this shield at shields.io](https://img.shields.io/discord/771316156203270154?color=7289da&logo=discord&logoColor=white)](https://github.com/supermerill/SuperSlicer/issues/611#issuecomment-907833287) [![you can get this shield at shields.io](https://img.shields.io/reddit/subreddit-subscribers/slic3r)](https://reddit.com/r/slic3r) [![Packaging status](https://repology.org/badge/tiny-repos/superslicer.svg)](https://repology.org/project/superslicer/versions) 
 # SuperSlicer
 
 **A PrusaSlicer fork (which is a slic3r fork)** (previously Slic3r++)


### PR DESCRIPTION
[![Packaging status](https://repology.org/badge/tiny-repos/superslicer.svg)](https://repology.org/project/superslicer/versions) 
This badge allow users to check fast if their distribution has packaged Superslicer.

A big version of the badge does also exist, but it does take a lot of space. 
[![Packaging status](https://repology.org/badge/vertical-allrepos/superslicer.svg)](https://repology.org/project/superslicer/versions)