### PR TITLE
Fixed window title for Retraction Calibration window #2218

### DIFF
--- a/src/slic3r/GUI/CalibrationRetractionDialog.hpp
+++ b/src/slic3r/GUI/CalibrationRetractionDialog.hpp
@@ -10,7 +10,7 @@ class CalibrationRetractionDialog : public CalibrationAbstractDialog
 {
 
 public:
-    CalibrationRetractionDialog(GUI_App* app, MainFrame* mainframe) : CalibrationAbstractDialog(app, mainframe, "Flow calibration") { create(boost::filesystem::path("calibration") / "retraction", "retraction.html", wxSize(900, 500));  }
+    CalibrationRetractionDialog(GUI_App* app, MainFrame* mainframe) : CalibrationAbstractDialog(app, mainframe, "Retraction calibration") { create(boost::filesystem::path("calibration") / "retraction", "retraction.html", wxSize(900, 500));  }
     virtual ~CalibrationRetractionDialog() {}
     
 protected:


### PR DESCRIPTION
Changed the titel of calibration retraction dialog from "Flow calibration" to "Retraction Calibration"