### PR TITLE
Support OneTBB version.h in CMake file

### DIFF
--- a/cmake/modules/FindTBB.cmake
+++ b/cmake/modules/FindTBB.cmake
@@ -195,7 +195,11 @@ if(NOT TBB_FOUND)
   ##################################
 
   if(TBB_INCLUDE_DIRS)
-    file(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _tbb_version_file)
+    if (EXISTS "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h")
+        file(READ "${TBB_INCLUDE_DIRS}/tbb/tbb_stddef.h" _tbb_version_file)
+    else()
+        file(READ "${TBB_INCLUDE_DIRS}/tbb/version.h" _tbb_version_file)
+    endif()
     string(REGEX REPLACE ".*#define TBB_VERSION_MAJOR ([0-9]+).*" "\\1"
         TBB_VERSION_MAJOR "${_tbb_version_file}")
     string(REGEX REPLACE ".*#define TBB_VERSION_MINOR ([0-9]+).*" "\\1"


### PR DESCRIPTION
The latest versions of OneTBB have removed tbb_stddef.h and put the version information in version.h.