### PR TITLE
Fix build on Linux

### DIFF
--- a/src/libslic3r/Fill/Lightning/DistanceField.cpp
+++ b/src/libslic3r/Fill/Lightning/DistanceField.cpp
@@ -2,8 +2,8 @@
 //CuraEngine is released under the terms of the AGPLv3 or higher.
 
 #include "DistanceField.hpp" //Class we're implementing.
-#include "../FillRectilinear.hpp"
 #include "../../ClipperUtils.hpp"
+#include "../FillRectilinear.hpp"
 
 namespace Slic3r::FillLightning
 {

--- a/src/libslic3r/Geometry/MedialAxis.cpp
+++ b/src/libslic3r/Geometry/MedialAxis.cpp
@@ -1,6 +1,9 @@
+#include <boost/log/trivial.hpp>
+
 #include "MedialAxis.hpp"
 
 #include "clipper.hpp"
+#include "../ClipperUtils.hpp"
 
 //#ifdef SLIC3R_DEBUG
 //namespace boost { namespace polygon {

--- a/src/libslic3r/PerimeterGenerator.cpp
+++ b/src/libslic3r/PerimeterGenerator.cpp
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <cassert>
 #include <list>
+#include <boost/log/trivial.hpp>
 
 namespace Slic3r {
 

--- a/src/slic3r/GUI/Field.cpp
+++ b/src/slic3r/GUI/Field.cpp
@@ -18,6 +18,7 @@
 #include <wx/richtooltip.h>
 #include <wx/tokenzr.h>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/log/trivial.hpp>
 #include "OG_CustomCtrl.hpp"
 #include "MsgDialog.hpp"
 #include "BitmapComboBox.hpp"

--- a/src/slic3r/GUI/GUI.cpp
+++ b/src/slic3r/GUI/GUI.cpp
@@ -10,6 +10,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/any.hpp>
+#include <boost/log/trivial.hpp>
 
 #if __APPLE__
 #import <IOKit/pwr_mgt/IOPMLib.h>

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1176,7 +1176,7 @@ bool GUI_App::on_init_inner()
         }
         wxString artist;
         if (!file_name.empty() && file_name != (std::string(SLIC3R_APP_NAME) + L(" icon"))) {
-            wxString splash_screen_path = wxString::FromUTF8((boost::filesystem::path(Slic3r::resources_dir()) / "splashscreen" / file_name).string());
+            wxString splash_screen_path = wxString::FromUTF8((boost::filesystem::path(Slic3r::resources_dir()) / "splashscreen" / file_name).string().c_str());
         // make a bitmap with dark grey banner on the left side
             bmp = SplashScreen::MakeBitmap(wxBitmap(splash_screen_path, wxBITMAP_TYPE_JPEG));
 
@@ -1463,11 +1463,13 @@ void GUI_App::update_label_colours_from_appconfig()
             m_color_label_phony = wxColour(str);
     }
 
+#ifdef _WIN32
     bool is_dark_mode = dark_mode();
     m_color_hovered_btn_label = is_dark_mode ? color_from_int(app_config->create_color(0.84f, 0.99f, AppConfig::EAppColorType::Main)) :
         color_from_int(app_config->create_color(1.00f, 0.99f, AppConfig::EAppColorType::Main));
     m_color_selected_btn_bg = is_dark_mode ? color_from_int(app_config->create_color(0.35f, 0.37f, AppConfig::EAppColorType::Main)) :
         color_from_int(app_config->create_color(0.05f, 0.9f, AppConfig::EAppColorType::Main));
+#endif
 
     //also update imgui color cache... can be moved if you have a better placee it 
     m_imgui->reset_color();

--- a/src/slic3r/GUI/MainFrame.cpp
+++ b/src/slic3r/GUI/MainFrame.cpp
@@ -2557,7 +2557,6 @@ void MainFrame::select_tab(ETabType tab /* = Any*/, bool keep_tab_type)
 #ifdef _MSW_DARK_MODE
         Notebook* notebook = static_cast<Notebook*>(m_tabpanel);
         //get the selected button, not the selected panel
-        int tab_sel = notebook->GetSelection();
         int bt_sel = notebook->GetButtonSelection();
 
         if (keep_tab_type && ((bt_sel >= 3 && tab <= ETabType::LastPlater) || (bt_sel < 3 && tab > ETabType::LastPlater))) {
@@ -2568,9 +2567,13 @@ void MainFrame::select_tab(ETabType tab /* = Any*/, bool keep_tab_type)
         } else {
             select(false);
             //force update if change from plater to plater
+#ifdef _MSW_DARK_MODE
             if (bt_sel != int(tab) && bt_sel < int(ETabType::LastPlater)) {
+#else
+            if (m_tabpanel->GetSelection() != int(tab) && m_tabpanel->GetSelection() < int(ETabType::LastPlater)) {
+#endif
                 wxBookCtrlEvent evt = wxBookCtrlEvent(wxEVT_BOOKCTRL_PAGE_CHANGED);
-                evt.SetOldSelection(tab_sel);
+                evt.SetOldSelection(m_tabpanel->GetSelection());
                 wxPostEvent(this, evt);
             }
         }

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2638,7 +2638,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             "The dimensions of the object from file %1% seem to be defined in meters.\n"
                             "The internal unit of %2% is a millimeter. Do you want to recalculate the dimensions of the object?",
                             "The dimensions of some objects from file %1% seem to be defined in meters.\n"
-                            "The internal unit of %2% is a millimeter. Do you want to recalculate the dimensions of these objects?", model.objects.size(), SLIC3R_APP_NAME), from_path(filename)) + "\n",
+                            "The internal unit of %2% is a millimeter. Do you want to recalculate the dimensions of these objects?", model.objects.size()), from_path(filename), SLIC3R_APP_NAME) + "\n",
                             _L("The object is too small"), wxICON_QUESTION | wxYES_NO);
                         dlg.ShowCheckBox(_L("Apply to all the remaining small objects being loaded."));
                         int answer = dlg.ShowModal();
@@ -2660,7 +2660,7 @@ std::vector<size_t> Plater::priv::load_files(const std::vector<fs::path>& input_
                             "The dimensions of the object from file %1% seem to be defined in inches.\n"
                             "The internal unit of %2% is a millimeter. Do you want to recalculate the dimensions of the object?",
                             "The dimensions of some objects from file %1% seem to be defined in inches.\n"
-                            "The internal unit of %2% is a millimeter. Do you want to recalculate the dimensions of these objects?", model.objects.size(), SLIC3R_APP_NAME), from_path(filename)) + "\n",
+                            "The internal unit of %2% is a millimeter. Do you want to recalculate the dimensions of these objects?", model.objects.size()), from_path(filename), SLIC3R_APP_NAME) + "\n",
                             _L("The object is too small"), wxICON_QUESTION | wxYES_NO);
                         dlg.ShowCheckBox(_L("Apply to all the remaining small objects being loaded."));
                         int answer = dlg.ShowModal();

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -142,7 +142,7 @@ public:
     Plater &operator=(const Plater &) = delete;
     ~Plater() = default;
 
-    const ProjectDirtyStateManager& Plater::get_dirty() const;
+    const ProjectDirtyStateManager& get_dirty() const;
     bool is_project_dirty() const;
     bool is_presets_dirty() const;
     void update_project_dirty_from_presets();

--- a/src/slic3r/GUI/Preferences.hpp
+++ b/src/slic3r/GUI/Preferences.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 class wxColourPickerCtrl;
+class wxBookCtrlBase;
 
 namespace Slic3r {
 


### PR DESCRIPTION
First time contributor here, so firstly, just wanted to say thanks for developing SuperSlicer! Really cool to have a tweak-focused slicer, giving proper control to the user.

I built the dev branch on Linux today, and there were some minor issues (mostly missing includes, a couple typos...), so here's a PR that gets the build working on Linux (for the most part, more on that below).

Almost everything was very straight forward, so there's not much to go wrong here. The only part I'm not 100% sure about is `src/slic3r/GUI/MainFrame.cpp`, since I "fixed" it just by interpreting the code around, and didn't look at the actual implementation enough to make sure the functionality is actually intact (but from what I see around, it seems to make sense).

Also note that I replaced `tab_sel` with a direct call to `m_tabpanel->GetSelection()` instead of adding another `ifdef`, since `Notebook` doesn't override that function, so as far as I can see it'd be redundant.

To get the build working on my system, I also had to remove the reference to `wxEVT_STC_AUTOCOMP_COMPLETED` from `src/slic3r/GUI/FreeCADDialog.cpp` (I just commented that line, since I don't need the functionality), but for obvious reasons, this change is not included in this PR. I needed to make this change because I'm running wxgtk 3.0.5 (the latest stable release), and that event is only present in the 3.1.x dev series.

It'd be great if that event could be replaced/removed, since it's the only wx symbol that is specific to 3.1.x, and it'd be a pity to sacrifice compatibility with the stable releases (which many distros ship), just for that one thing. As a side note, it might also be a good idea to add a build flag to make the FreeCAD integration optional, since I suspect a lot of people wouldn't need it for development (would a patch for this be welcome?).

Lastly, it might be interesting to look at adding some extra compiler flags, as it seems like MSVC (which I assume is what you are working on) is being a bit too lenient. While some of the issues were about platform-specific code wrapped in `ifdef`s, which MSVC obviously wouldn't be able to catch, there were also things that I would've expected MSVC to catch. The missing/mis-sorted includes, for one, but also the incorrect parameter count in `src/slic3r/GUI/Plater.cpp` (the only change in this PR that actually fixes functionality additionally to the related build error). Those kinds of mistakes are super easy to make, but I think MSVC should be able to catch them with the right build flags.