### PR TITLE
Fix icon scaling causing crash on startup

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -5266,8 +5266,8 @@ void GLCanvas3D::_check_and_update_toolbar_icon_scale() const
     int   items_cnt = m_main_toolbar.get_visible_items_cnt() + m_undoredo_toolbar.get_visible_items_cnt() + collapse_toolbar.get_visible_items_cnt();
     float noitems_width = top_tb_width - size * items_cnt; // width of separators and borders in top toolbars 
 
-    // calculate scale needed for items in all top toolbars
-    float new_h_scale = (cnv_size.get_width() - noitems_width) / (items_cnt * GLToolbar::Default_Icons_Size);
+    // calculate scale needed for items in all top toolbars (make sure the size is positive even if `cnv_size` is less than `noitems_width`)
+    float new_h_scale = std::max((cnv_size.get_width() - noitems_width), 1.0f) / (items_cnt * GLToolbar::Default_Icons_Size);
 
     items_cnt = m_gizmos.get_selectable_icons_cnt() + 3; // +3 means a place for top and view toolbars and separators in gizmos toolbar
 

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -1199,10 +1199,6 @@ float GUI_App::toolbar_icon_scale(const bool is_limited/* = false*/) const
 
     if (is_limited && int_val < 50)
         int_val = 50;
-    else if (int_val < 1) {
-        int_val = 10; //buggy code? issue supermerill/superslicer#854
-        assert(false);
-    }
 
     return 0.01f * int_val * icon_sc;
 }


### PR DESCRIPTION
Icons can get scaled even if the window is not yet fully initialised, in which case they ended up with a negative scale.

Potentially related to supermerill/SuperSlicer#854.