### PR TITLE
Fixed typo

### DIFF
--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -489,7 +489,7 @@ void PrintConfigDef::init_fff_params()
     def->label = L("Max angle");
     def->full_label = L("Brim ear max angle");
     def->category = OptionCategory::skirtBrim;
-    def->tooltip = L("Maximum angle to let a brim ear appear. \nIf set to 0, no brim will be created. \nIf set to ~178, brim will be created on everything but strait sections.");
+    def->tooltip = L("Maximum angle to let a brim ear appear. \nIf set to 0, no brim will be created. \nIf set to ~178, brim will be created on everything but straight sections.");
     def->sidetext = L("°");
     def->min = 0;
     def->max = 180;


### PR DESCRIPTION
Fixed a typo for the brim ears max angle tooltip.

Made after opening #2404