### PR TITLE
Fix for failing MacOS builds because of zstd

### DIFF
--- a/BuildMacOS.sh
+++ b/BuildMacOS.sh
@@ -47,6 +47,7 @@ ls /usr/local/opt/zstd/lib
 echo "\nbrew --prefix zstd:\n"
 brew --prefix zstd
 
+export LIBRARY_PATH=$LIBRARY_PATH:$(brew --prefix zstd)/lib/
 
 # mkdir build
 if [ ! -d "build" ]


### PR DESCRIPTION
i'm not sure if this pull request ist against the correct branch, but this fixes the currently failing MacOS builds.
i tested on my fork: https://github.com/mneuhaus/SuperSlicer/actions