### PR TITLE
Tool change temp bugfix

### DIFF
--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -402,7 +402,7 @@ public:
             gcode << "P";
         } else if (this->m_gcode_flavor == (gcfRepRap)) {
             gcode << "P" << tool << " S";
-        } else if (this->m_gcode_flavor == (gcfMarlinFirmware) || this->m_gcode_flavor == (gcfMarlinLegacy) && wait) {
+        } else if ((this->m_gcode_flavor == (gcfMarlinFirmware) || this->m_gcode_flavor == (gcfMarlinLegacy)) && wait) {
             gcode << "R";
         }
         else {


### PR DESCRIPTION
A small bug was introduced when merging the changes made for: https://github.com/supermerill/SuperSlicer/issues/2611. The wait should be a requirement (so wait && (MarlinLegacy || Marlin)) which is not the case right now. This allows for a command like M104 R[temp] to go through when using Marlin flavor (non legacy) which doesn't  exist.

