### PR TITLE
Fixed Download Link of Slicer in the Update Message

### DIFF
--- a/src/slic3r/GUI/UpdateDialogs.cpp
+++ b/src/slic3r/GUI/UpdateDialogs.cpp
@@ -26,7 +26,7 @@ namespace GUI {
 
 static const char* URL_CHANGELOG = "https://github.com/" SLIC3R_GITHUB "/releases";
 static const char* URL_DOWNLOAD = "https://github.com/" SLIC3R_GITHUB "/releases";
-static const char* URL_DEV = "https://github.com/" SLIC3R_GITHUB "/releases/tag/version_%1%";
+static const char* URL_DEV = "https://github.com/" SLIC3R_GITHUB "/releases/tag/%1%";
 
 static const std::string CONFIG_UPDATE_WIKI_URL("https://github.com/prusa3d/PrusaSlicer/wiki/Slic3r-PE-1.40-configuration-update");
 


### PR DESCRIPTION
Nothing Fancy here
I was annoyed that the download link didn't work