### PR TITLE
Added Client certificate authentication to physical printer options #2269

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3288,7 +3288,6 @@ void GCode::append_full_config(const Print &print, std::string &str)
         "printhost_cafile",
         "printhost_client_cert",
         "printhost_client_cert_password",
-        "printhost_client_cert_enabled",
         "printhost_port"
     };
     assert(std::is_sorted(banned_keys.begin(), banned_keys.end()));

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -3287,6 +3287,8 @@ void GCode::append_full_config(const Print &print, std::string &str)
         "printhost_apikey",
         "printhost_cafile",
         "printhost_client_cert",
+        "printhost_client_cert_password",
+        "printhost_client_cert_enabled",
         "printhost_port"
     };
     assert(std::is_sorted(banned_keys.begin(), banned_keys.end()));

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1778,7 +1778,6 @@ static std::vector<std::string> s_PhysicalPrinter_opts {
     "printhost_apikey",
     "printhost_cafile",
     "printhost_client_cert",
-    "printhost_client_cert_enabled",
     "printhost_client_cert_password",
     "printhost_port",
     "printhost_authorization_type",

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -1778,6 +1778,8 @@ static std::vector<std::string> s_PhysicalPrinter_opts {
     "printhost_apikey",
     "printhost_cafile",
     "printhost_client_cert",
+    "printhost_client_cert_enabled",
+    "printhost_client_cert_password",
     "printhost_port",
     "printhost_authorization_type",
     // HTTP digest authentization (RFC 2617)
@@ -1824,14 +1826,15 @@ const std::set<std::string>& PhysicalPrinter::get_preset_names() const
 
 bool PhysicalPrinter::has_empty_config() const
 {
-    return  config.opt_string("print_host"        ).empty() &&
-            config.opt_string("printhost_apikey"  ).empty() &&
-            config.opt_string("printhost_cafile"  ).empty() &&
-            config.opt_string("printhost_client_cert").empty() && 
-            config.opt_string("printhost_port"    ).empty() &&
-            config.opt_string("printhost_user"    ).empty() &&
-            config.opt_string("printhost_password").empty() && 
-            config.opt_string("printhost_port"    ).empty();
+    return  config.opt_string("print_host"                      ).empty() &&
+            config.opt_string("printhost_apikey"                ).empty() &&
+            config.opt_string("printhost_cafile"                ).empty() &&
+            config.opt_string("printhost_client_cert"           ).empty() && 
+            config.opt_string("printhost_client_cert_password"  ).empty() && 
+            config.opt_string("printhost_port"                  ).empty() &&
+            config.opt_string("printhost_user"                  ).empty() &&
+            config.opt_string("printhost_password"              ).empty() && 
+            config.opt_string("printhost_port"                  ).empty();
 }
 
 // temporary workaround for compatibility with older Slicer

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -498,13 +498,6 @@ void PrintConfigDef::init_common_params()
     def->mode = comAdvancedE | comSuSi;
     def->set_default_value(new ConfigOptionString(""));
 
-    def = this->add("printhost_client_cert_enabled", coBool);
-    def->label = L("Enable 2-way ssl authentication");
-    def->category = OptionCategory::general;
-    def->tooltip = L("Use this option to enable 2-way ssl authentication with you printer");
-    def->mode = comAdvancedE | comSuSi;
-    def->set_default_value(new ConfigOptionBool(false));
-
     def = this->add("printhost_client_cert_password", coString);
     def->label = L("Client Certificate Password");
     def->category = OptionCategory::general;
@@ -7247,7 +7240,6 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "print_retract_lift",
 "print_temperature",
 "printhost_client_cert",
-"printhost_client_cert_enabled",
 "printhost_client_cert_password",
 "remaining_times_type",
 "retract_lift_first_layer",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -493,9 +493,24 @@ void PrintConfigDef::init_common_params()
     def = this->add("printhost_client_cert", coString);
     def->label = L("Client Certificate File");
     def->category = OptionCategory::general;
-    def->tooltip = L("Custom Client certificate file can be specified for 2-way ssl authentication, in p12/pfx format. "
+    def->tooltip = L("A Client certificate file for use with 2-way ssl authentication, in p12/pfx format. "
                    "If left blank, no client certificate is used.");
     def->mode = comAdvancedE | comSuSi;
+    def->set_default_value(new ConfigOptionString(""));
+
+    def = this->add("printhost_client_cert_enabled", coBool);
+    def->label = L("Enable 2-way ssl authentication");
+    def->category = OptionCategory::general;
+    def->tooltip = L("Use this option to enable 2-way ssl authentication with you printer");
+    def->mode = comAdvancedE | comSuSi;
+    def->set_default_value(new ConfigOptionBool(false));
+
+    def = this->add("printhost_client_cert_password", coString);
+    def->label = L("Client Certificate Password");
+    def->category = OptionCategory::general;
+    def->tooltip = L("Password for client certificate for 2-way ssl authentication. "
+                   "Leave blank if no password is needed");
+    def->mode = comAdvanced;
     def->set_default_value(new ConfigOptionString(""));
 
     // Options used by physical printers
@@ -7232,6 +7247,8 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "print_retract_lift",
 "print_temperature",
 "printhost_client_cert",
+"printhost_client_cert_enabled",
+"printhost_client_cert_password",
 "remaining_times_type",
 "retract_lift_first_layer",
 "retract_lift_top",

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -322,7 +322,7 @@ void PhysicalPrinterDialog::update_printers()
 void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgroup)
 {
     m_optgroup->m_on_change = [this](t_config_option_key opt_key, boost::any value) {
-        if (opt_key == "host_type" || opt_key == "printhost_authorization_type")
+        if (opt_key == "host_type" || opt_key == "printhost_authorization_type" || opt_key == "printhost_client_cert_enabled")
             this->update();
         if (opt_key == "print_host")
             this->update_printhost_buttons();
@@ -408,6 +408,10 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     port_line.append_widget(print_host_printers);
     m_optgroup->append_line(port_line);
 
+    option = m_optgroup->get_option("printhost_client_cert_enabled");
+    option.opt.width = Field::def_width_wider();
+    m_optgroup->append_single_option_line(option);
+
     option = m_optgroup->get_option("printhost_client_cert");
     option.opt.width = Field::def_width_wider();
     Line client_cert_line = m_optgroup->create_single_option_line(option);
@@ -440,6 +444,10 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
         return sizer;
     };
     m_optgroup->append_line(clientcert_hint);
+
+    option = m_optgroup->get_option("printhost_client_cert_password");
+    option.opt.width = Field::def_width_wider();
+    m_optgroup->append_single_option_line(option);
 
     const auto ca_file_hint = _u8L("HTTPS CA file is optional. It is only needed if you use HTTPS with a self-signed certificate.");
 
@@ -586,6 +594,11 @@ void PhysicalPrinterDialog::update(bool printer_change)
             m_optgroup->hide_field("printhost_apikey");
             m_optgroup->hide_field("printhost_cafile");
         }
+
+        // Hide client cert options if disabled
+        const bool enable_client_authentication = m_config->option<ConfigOptionBool>("printhost_client_cert_enabled")->value;
+        m_optgroup->show_field("printhost_client_cert", enable_client_authentication);
+        m_optgroup->show_field("printhost_client_cert_password", enable_client_authentication);
     }
     else {
         m_optgroup->set_value("host_type", int(PrintHostType::htOctoPrint), false);
@@ -614,6 +627,7 @@ void PhysicalPrinterDialog::update(bool printer_change)
     }
 
     this->Layout();
+    this->Fit();
 }
 
 void PhysicalPrinterDialog::update_host_type(bool printer_change)

--- a/src/slic3r/GUI/PhysicalPrinterDialog.cpp
+++ b/src/slic3r/GUI/PhysicalPrinterDialog.cpp
@@ -412,6 +412,7 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     option.opt.width = Field::def_width_wider();
     m_optgroup->append_single_option_line(option);
 
+#ifndef __APPLE__
     option = m_optgroup->get_option("printhost_client_cert");
     option.opt.width = Field::def_width_wider();
     Line client_cert_line = m_optgroup->create_single_option_line(option);
@@ -433,6 +434,23 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
     client_cert_line.append_widget(printhost_client_cert_browse);
     m_optgroup->append_line(client_cert_line);
 
+    option = m_optgroup->get_option("printhost_client_cert_password");
+    option.opt.width = Field::def_width_wider();
+    m_optgroup->append_single_option_line(option);
+#else // __APPLE__
+    const auto client_cert_hint = _u8L("To use a client cert on MacOS, add your certificate to your keychain and make sure it's trusted.");
+
+    Line clientcert_hint{ "", "" };
+    clientcert_hint.full_width = 1;
+    clientcert_hint.widget = [this, client_cert_hint](wxWindow* parent) {
+        auto txt = new wxStaticText(parent, wxID_ANY, client_cert_hint);
+        auto sizer = new wxBoxSizer(wxHORIZONTAL);
+        sizer->Add(txt);
+        return sizer;
+    };
+    m_optgroup->append_line(clientcert_hint);
+#endif // __APPLE__
+
     const auto client_cert_hint = _u8L("Client certificate file is optional. It is only needed if you use 2-way ssl.");
 
     Line clientcert_hint{ "", "" };
@@ -444,10 +462,6 @@ void PhysicalPrinterDialog::build_printhost_settings(ConfigOptionsGroup* m_optgr
         return sizer;
     };
     m_optgroup->append_line(clientcert_hint);
-
-    option = m_optgroup->get_option("printhost_client_cert_password");
-    option.opt.width = Field::def_width_wider();
-    m_optgroup->append_single_option_line(option);
 
     const auto ca_file_hint = _u8L("HTTPS CA file is optional. It is only needed if you use HTTPS with a self-signed certificate.");
 
@@ -595,10 +609,12 @@ void PhysicalPrinterDialog::update(bool printer_change)
             m_optgroup->hide_field("printhost_cafile");
         }
 
+#ifndef __APPLE__
         // Hide client cert options if disabled
         const bool enable_client_authentication = m_config->option<ConfigOptionBool>("printhost_client_cert_enabled")->value;
         m_optgroup->show_field("printhost_client_cert", enable_client_authentication);
         m_optgroup->show_field("printhost_client_cert_password", enable_client_authentication);
+#endif
     }
     else {
         m_optgroup->set_value("host_type", int(PrintHostType::htOctoPrint), false);

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -522,10 +522,11 @@ Http& Http::ca_file(const std::string &name)
 	return *this;
 }
 
-Http& Http::client_cert(const std::string &name)
+Http& Http::client_cert(const std::string &name, const std::string &password)
 {
 	curl_easy_setopt(p->curl, CURLOPT_SSLCERT, name.c_str());
 	curl_easy_setopt(p->curl, CURLOPT_SSLCERTTYPE, "P12");
+	curl_easy_setopt(p->curl, CURLOPT_KEYPASSWD, password.c_str());
 
 	return *this;
 }

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -525,8 +525,10 @@ Http& Http::ca_file(const std::string &name)
 Http& Http::client_cert(const std::string &name, const std::string &password)
 {
 	curl_easy_setopt(p->curl, CURLOPT_SSLCERT, name.c_str());
+#ifndef __APPLE__ // Only use this on non macos machines
 	curl_easy_setopt(p->curl, CURLOPT_SSLCERTTYPE, "P12");
 	curl_easy_setopt(p->curl, CURLOPT_KEYPASSWD, password.c_str());
+#endif // __APPLE__
 
 	return *this;
 }

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -525,10 +525,8 @@ Http& Http::ca_file(const std::string &name)
 Http& Http::client_cert(const std::string &name, const std::string &password)
 {
 	curl_easy_setopt(p->curl, CURLOPT_SSLCERT, name.c_str());
-#ifndef __APPLE__ // Only use this on non macos machines
 	curl_easy_setopt(p->curl, CURLOPT_SSLCERTTYPE, "P12");
 	curl_easy_setopt(p->curl, CURLOPT_KEYPASSWD, password.c_str());
-#endif // __APPLE__
 
 	return *this;
 }

--- a/src/slic3r/Utils/Http.hpp
+++ b/src/slic3r/Utils/Http.hpp
@@ -79,8 +79,8 @@ public:
 	// specifically, this is supported with OpenSSL and NOT supported with Windows and OS X native certificate store.
 	// See also ca_file_supported().
 	Http& ca_file(const std::string &filename);
-	// Set a client certificate for usage with 2-way ssl authentication
-	Http& client_cert(const std::string &filename);
+	// Set a client certificate for usage with 2-way ssl authentication (password for key is optional)
+	Http& client_cert(const std::string &filename, const std::string &password = "");
 	// Add a HTTP multipart form field
 	Http& form_add(const std::string &name, const std::string &contents);
 	// Add a HTTP multipart form file data contents, `name` is the name of the part

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -99,6 +99,8 @@ OctoPrint::OctoPrint(DynamicPrintConfig *config) :
     m_apikey(config->opt_string("printhost_apikey")),
     m_cafile(config->opt_string("printhost_cafile")),
     m_client_cert(config->opt_string("printhost_client_cert")),
+    m_client_cert_password(config->opt_string("printhost_client_cert_password")),
+    m_client_cert_enabled(config->opt_bool("printhost_client_cert_enabled")),
     m_ssl_revoke_best_effort(config->opt_bool("printhost_ssl_ignore_revoke"))
 {}
 
@@ -277,8 +279,8 @@ void OctoPrint::set_auth(Http &http) const
         http.ca_file(m_cafile);
     }
 
-    if (! m_client_cert.empty()) {
-        http.client_cert(m_client_cert);
+    if (! m_client_cert.empty() && m_client_cert_enabled) {
+        http.client_cert(m_client_cert, m_client_cert_password);
     }
 }
 
@@ -373,8 +375,8 @@ void SL1Host::set_auth(Http &http) const
         http.ca_file(get_cafile());
     }
 
-    if (! get_client_cert().empty()) {
-        http.client_cert(get_client_cert());
+    if (!get_client_cert().empty() && get_client_cert_enabled()) {
+        http.client_cert(get_client_cert(), get_client_cert_password());
     }
 }
 
@@ -421,8 +423,8 @@ void PrusaLink::set_auth(Http& http) const
         http.ca_file(get_cafile());
     }
 
-    if (! get_client_cert().empty()) {
-        http.client_cert(get_client_cert());
+    if (! get_client_cert().empty() && get_client_cert_enabled()) {
+        http.client_cert(get_client_cert(), get_client_cert_password());
     }
 }
 

--- a/src/slic3r/Utils/OctoPrint.cpp
+++ b/src/slic3r/Utils/OctoPrint.cpp
@@ -100,7 +100,6 @@ OctoPrint::OctoPrint(DynamicPrintConfig *config) :
     m_cafile(config->opt_string("printhost_cafile")),
     m_client_cert(config->opt_string("printhost_client_cert")),
     m_client_cert_password(config->opt_string("printhost_client_cert_password")),
-    m_client_cert_enabled(config->opt_bool("printhost_client_cert_enabled")),
     m_ssl_revoke_best_effort(config->opt_bool("printhost_ssl_ignore_revoke"))
 {}
 
@@ -279,7 +278,7 @@ void OctoPrint::set_auth(Http &http) const
         http.ca_file(m_cafile);
     }
 
-    if (! m_client_cert.empty() && m_client_cert_enabled) {
+    if (! m_client_cert.empty()) {
         http.client_cert(m_client_cert, m_client_cert_password);
     }
 }
@@ -375,7 +374,7 @@ void SL1Host::set_auth(Http &http) const
         http.ca_file(get_cafile());
     }
 
-    if (!get_client_cert().empty() && get_client_cert_enabled()) {
+    if (!get_client_cert().empty()) {
         http.client_cert(get_client_cert(), get_client_cert_password());
     }
 }
@@ -423,7 +422,7 @@ void PrusaLink::set_auth(Http& http) const
         http.ca_file(get_cafile());
     }
 
-    if (! get_client_cert().empty() && get_client_cert_enabled()) {
+    if (! get_client_cert().empty()) {
         http.client_cert(get_client_cert(), get_client_cert_password());
     }
 }

--- a/src/slic3r/Utils/OctoPrint.hpp
+++ b/src/slic3r/Utils/OctoPrint.hpp
@@ -33,6 +33,9 @@ public:
     const std::string& get_apikey() const { return m_apikey; }
     const std::string& get_cafile() const { return m_cafile; }
     const std::string& get_client_cert() const { return m_client_cert; }
+    const std::string& get_client_cert_password() const { return m_client_cert_password; }
+    const bool get_client_cert_enabled() const { return m_client_cert_enabled; }
+
 
 protected:
     virtual bool validate_version_text(const boost::optional<std::string> &version_text) const;
@@ -44,6 +47,8 @@ private:
     std::string m_cafile;
     bool        m_ssl_revoke_best_effort;
     std::string m_client_cert;
+    std::string m_client_cert_password;
+    bool m_client_cert_enabled;
 
     virtual void set_auth(Http &http) const;
     std::string make_url(const std::string &path) const;

--- a/src/slic3r/Utils/OctoPrint.hpp
+++ b/src/slic3r/Utils/OctoPrint.hpp
@@ -34,7 +34,6 @@ public:
     const std::string& get_cafile() const { return m_cafile; }
     const std::string& get_client_cert() const { return m_client_cert; }
     const std::string& get_client_cert_password() const { return m_client_cert_password; }
-    const bool get_client_cert_enabled() const { return m_client_cert_enabled; }
 
 
 protected:
@@ -48,7 +47,6 @@ private:
     bool        m_ssl_revoke_best_effort;
     std::string m_client_cert;
     std::string m_client_cert_password;
-    bool m_client_cert_enabled;
 
     virtual void set_auth(Http &http) const;
     std::string make_url(const std::string &path) const;


### PR DESCRIPTION
Due to some issues with merging the master branch in PR #2283 I've recreated this PR.
This PR only contains my changes, added onto a clean master branch.

Latest changes:
- Added a toggle for adding a client cert.
- Added a password field, to use with password protected client certificate files.

Todo list:
- Build/Test on MacOS
- Build/Test on Windows

Any suggestions on how I can build these and test them would be appreciated