### PR TITLE
Boost 1.79 port + bunch of missing includes all over the place.

### DIFF
--- a/src/hints/HintsToPot.cpp
+++ b/src/hints/HintsToPot.cpp
@@ -9,7 +9,7 @@
 
 bool write_to_pot(boost::filesystem::path path, const std::vector<std::pair<std::string, std::string>>& data)
 {
-	boost::filesystem::ofstream file(std::move(path), std::ios_base::app);
+	boost::nowide::ofstream file(std::move(path), std::ios_base::app);
 	for (const auto& element : data)
 	{
 		//Example of .pot element 

--- a/src/libslic3r/AppConfig.cpp
+++ b/src/libslic3r/AppConfig.cpp
@@ -1,5 +1,6 @@
 #include "libslic3r/libslic3r.h"
 #include "libslic3r/Utils.hpp"
+#include "libslic3r/I18N.hpp"
 #include "AppConfig.hpp"
 #include "Exception.hpp"
 #include "LocalesUtils.hpp"

--- a/src/libslic3r/AppConfig.hpp
+++ b/src/libslic3r/AppConfig.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <string>
 
+#include <boost/filesystem/path.hpp>
 #include <boost/algorithm/string/trim_all.hpp>
 
 #include "libslic3r/Config.hpp"

--- a/src/libslic3r/LocalesUtils.cpp
+++ b/src/libslic3r/LocalesUtils.cpp
@@ -8,6 +8,7 @@
 
 #include <fast_float/fast_float.h>
 
+#include <boost/lexical_cast.hpp>
 
 namespace Slic3r {
 

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -84,7 +84,7 @@ ConfigFileType guess_config_file_type(const ptree &tree)
 VendorProfile VendorProfile::from_ini(const boost::filesystem::path &path, bool load_all)
 {
     ptree tree;
-    boost::filesystem::ifstream ifs(path);
+    boost::nowide::ifstream ifs(path);
     boost::property_tree::read_ini(ifs, tree);
     return VendorProfile::from_ini(tree, path, load_all);
 }

--- a/src/slic3r/GUI/CreateMMUTiledCanvas.cpp
+++ b/src/slic3r/GUI/CreateMMUTiledCanvas.cpp
@@ -35,8 +35,13 @@
 #include <wx/odcombo.h>
 #include <wx/textctrl.h>
 #include <wx/wrapsizer.h>
+#include <wx/rawbmp.h>
 #include "wxExtensions.hpp"
 
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/ini_parser.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/nowide/fstream.hpp>
 

--- a/src/slic3r/GUI/DesktopIntegrationDialog.cpp
+++ b/src/slic3r/GUI/DesktopIntegrationDialog.cpp
@@ -14,6 +14,7 @@
 #include <boost/log/trivial.hpp>
 #include <boost/dll/runtime_symbol_info.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/nowide/fstream.hpp>
 
 #include <wx/filename.h>
 #include <wx/stattext.h>

--- a/src/slic3r/GUI/FreeCADDialog.cpp
+++ b/src/slic3r/GUI/FreeCADDialog.cpp
@@ -38,6 +38,7 @@
 #include <boost/log/trivial.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
+#include <boost/nowide/fstream.hpp>
 
 // hack for process.hpp : it uses pid_t to set it as alias of int, but vc_x64_lib (wx thingy) as a '#define pid_t int'
 // and so boost/process has a line 'typedef int int'instead of 'typedef int pid_t' that makes it crash
@@ -321,7 +322,7 @@ bool FreeCADDialog::load_text_from_file(const boost::filesystem::path &path) {
         try {
             std::locale loc = boost::locale::generator()("en_US.UTF-8");
             // Open the stream to 'lock' the file.
-            boost::filesystem::ifstream in;
+            boost::nowide::ifstream in;
             in.imbue(loc);
             in.open(path);
             // Obtain the size of the file.
@@ -368,7 +369,7 @@ bool FreeCADDialog::write_text_in_file(const wxString &towrite, const boost::fil
         boost::filesystem::create_directories(file.parent_path());
         std::locale loc = boost::locale::generator()("en_US.UTF-8");
         // Open the stream to 'lock' the file.
-        boost::filesystem::ofstream out;
+        boost::nowide::ofstream out;
         out.imbue(loc);
         out.open(file);
         out << towrite;

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -19,6 +19,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/nowide/convert.hpp>
+#include <boost/nowide/fstream.hpp>
 
 #include <wx/stdpaths.h>
 #include <wx/imagpng.h>

--- a/src/slic3r/GUI/HintNotification.cpp
+++ b/src/slic3r/GUI/HintNotification.cpp
@@ -65,7 +65,7 @@ inline void push_style_color(ImGuiCol idx, const ImVec4& col, bool fading_out, f
 
 void write_used_binary(const std::vector<std::string>& ids)
 {
-	boost::filesystem::ofstream file((boost::filesystem::path(data_dir()) / "cache" / "hints.cereal"), std::ios::binary);
+	boost::nowide::ofstream file((boost::filesystem::path(data_dir()) / "cache" / "hints.cereal"), std::ios::binary);
 	cereal::BinaryOutputArchive archive(file);
 		HintsCerealData cd { ids };
 	try
@@ -84,7 +84,7 @@ void read_used_binary(std::vector<std::string>& ids)
 		BOOST_LOG_TRIVIAL(warning) << "Failed to load to hints.cereal. File does not exists. " << path.string();
 		return;
 	}
-	boost::filesystem::ifstream file(path);
+	boost::nowide::ifstream file(path);
 	cereal::BinaryInputArchive archive(file);
 	HintsCerealData cd;
 	try

--- a/src/slic3r/GUI/Preferences.cpp
+++ b/src/slic3r/GUI/Preferences.cpp
@@ -12,6 +12,7 @@
 #include "OG_CustomCtrl.hpp"
 #include "wxExtensions.hpp"
 
+#include <boost/algorithm/string/split.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>
 

--- a/src/slic3r/GUI/ScriptExecutor.cpp
+++ b/src/slic3r/GUI/ScriptExecutor.cpp
@@ -5,6 +5,14 @@
 #include "libslic3r/PresetBundle.hpp"
 #include "libslic3r/Print.hpp"
 
+#include <boost/log/trivial.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string/trim_all.hpp>
+#include <boost/algorithm/string/erase.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/string_file.hpp>
+
 #include <string>
 
 #include <angelscript/source/as_config.h>

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -36,6 +36,8 @@
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/nowide/fstream.hpp>
+#include <boost/log/trivial.hpp>
 
 #include "wxExtensions.hpp"
 #include "PresetComboBoxes.hpp"
@@ -1692,7 +1694,7 @@ std::vector<Slic3r::GUI::PageShp> Tab::create_pages(std::string setting_type_nam
 
     //read file
     //std::ifstream filestream(ui_layout_file.c_str());
-    boost::filesystem::ifstream filestream(ui_layout_file);
+    boost::nowide::ifstream filestream(ui_layout_file);
     std::string full_line;
     while (std::getline(filestream, full_line)) {
         //remove spaces

--- a/src/slic3r/Utils/Http.cpp
+++ b/src/slic3r/Utils/Http.cpp
@@ -11,6 +11,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/log/trivial.hpp>
+#include <boost/nowide/fstream.hpp>
 
 #include <curl/curl.h>
 
@@ -52,7 +53,7 @@ namespace Slic3r {
 						% error;
 			})
 			.on_complete([&](std::string body, unsigned /* http_status */) {
-				boost::filesystem::fstream file(tmp_path, std::ios::out | std::ios::binary | std::ios::trunc);
+				boost::nowide::fstream file(tmp_path, std::ios::out | std::ios::binary | std::ios::trunc);
 				file.write(body.c_str(), body.size());
 				file.close();
 				boost::filesystem::rename(tmp_path, target_path);


### PR DESCRIPTION
This solves all boost and missing includes related build failures on the
modern Linux distributions.

I have bunch of other fixes that will allow building it without any patching on modern Linux systems, however those depends on this very changeset, chance why I send it first.

@supermerill One thing that bothers me is, I do not quite understand how it could build for you with all those missing includes, perhaps your build environment involuntarily adds a number of includes and this is why it works? A mystery. :sweat_smile: 