### PR TITLE
TFT thumbnails

### DIFF
--- a/src/libslic3r/GCode/Thumbnails.cpp
+++ b/src/libslic3r/GCode/Thumbnails.cpp
@@ -83,7 +83,39 @@ std::unique_ptr<CompressedImageBuffer> compress_thumbnail_biqu(const ThumbnailDa
 
 std::unique_ptr<CompressedImageBuffer> compress_thumbnail_tft(const ThumbnailData& data)
 {
-    // TODO
+    auto out = std::make_unique<CompressedTFT>();
+    //size: height is number of lines. Add 9 byte to each line for the 'M10086 ;' and '\n'. Each pixel is 4 byte, +1 for the 0 of the c_str
+    out->size = data.height * (9 + data.width * 4) + 1;
+    out->data = malloc(out->size);
+
+    // Take vector of RGBA pixels and flip the image vertically
+    std::vector<uint8_t> rgba_pixels(data.pixels.size());
+    const size_t row_size = data.width * 4;
+    for (size_t y = 0; y < data.height; ++y)
+        ::memcpy(rgba_pixels.data() + (data.height - y - 1) * row_size, data.pixels.data() + y * row_size, row_size);
+
+    int idx = 0;
+    std::stringstream tohex;
+    tohex << std::setfill('0') << std::hex;
+    for (size_t y = 0; y < data.height; ++y) {
+        tohex << "M10086 ;";
+        for (size_t x = 0; x < data.width; ++x) {
+            uint16_t pixel = 0;
+            //r
+            pixel |= uint16_t((rgba_pixels[y * row_size + x * 4 + 0 ] & 0x000000F8) >> 3);
+            //g
+            pixel |= uint16_t((rgba_pixels[y * row_size + x * 4 + 1 ] & 0x000000FC) << 3);
+            //b
+            pixel |= uint16_t((rgba_pixels[y * row_size + x * 4 + 2 ] & 0x000000F8) << 8);
+            tohex << std::setw(4) << pixel;
+        }
+        tohex << "\n";
+    }
+    std::string str = tohex.str();
+
+    assert(str.size() + 1 == out->size);
+    ::memcpy(out->data, (const void*)str.c_str(), out->size);
+    return out;
 }
 
 std::unique_ptr<CompressedImageBuffer> compress_thumbnail_jpg(const ThumbnailData& data)

--- a/src/libslic3r/GCode/Thumbnails.cpp
+++ b/src/libslic3r/GCode/Thumbnails.cpp
@@ -32,6 +32,12 @@ struct CompressedBIQU : CompressedImageBuffer
     std::string_view tag() const override { return "thumbnail_BIQU"sv; }
 };
 
+struct CompressedTFT : CompressedImageBuffer
+{
+    ~CompressedTFT() override { free(data); }
+    std::string_view tag() const override { return "thumbnail_TFT"sv; }
+};
+
 std::unique_ptr<CompressedImageBuffer> compress_thumbnail_png(const ThumbnailData& data)
 {
     auto out = std::make_unique<CompressedPNG>();
@@ -73,6 +79,11 @@ std::unique_ptr<CompressedImageBuffer> compress_thumbnail_biqu(const ThumbnailDa
     assert(str.size() + 1 == out->size);
     ::memcpy(out->data, (const void*)str.c_str(), out->size);
     return out;
+}
+
+std::unique_ptr<CompressedImageBuffer> compress_thumbnail_tft(const ThumbnailData& data)
+{
+    // TODO
 }
 
 std::unique_ptr<CompressedImageBuffer> compress_thumbnail_jpg(const ThumbnailData& data)
@@ -135,6 +146,8 @@ std::unique_ptr<CompressedImageBuffer> compress_thumbnail(const ThumbnailData &d
             return compress_thumbnail_qoi(data);
         case GCodeThumbnailsFormat::BIQU:
             return compress_thumbnail_biqu(data);
+        case GCodeThumbnailsFormat::TFT:
+            return compress_thumbnail_tft(data);
     }
 }
 

--- a/src/libslic3r/GCode/Thumbnails.hpp
+++ b/src/libslic3r/GCode/Thumbnails.hpp
@@ -54,6 +54,9 @@ inline void export_thumbnails_to_file(ThumbnailsGeneratorCallback &thumbnail_cb,
                         else
                             assert(false);
                         output("; bigtree thumbnail end\n");
+                    }
+                    else if (format == GCodeThumbnailsFormat::TFT) {
+                        // TODO
                     } else {
                         std::string encoded;
                         encoded.resize(boost::beast::detail::base64::encoded_size(compressed->size));

--- a/src/libslic3r/GCode/Thumbnails.hpp
+++ b/src/libslic3r/GCode/Thumbnails.hpp
@@ -37,6 +37,7 @@ inline void export_thumbnails_to_file(ThumbnailsGeneratorCallback &thumbnail_cb,
         //Create the thumbnails
         static constexpr const size_t max_row_length = 78;
         ThumbnailsList thumbnails = thumbnail_cb(ThumbnailsParams{ good_sizes, true, true, with_bed, true });
+        image_count = 0
         for (const ThumbnailData& data : thumbnails)
             if (data.is_valid()) {
                 auto compressed = compress_thumbnail(data, format);
@@ -56,7 +57,25 @@ inline void export_thumbnails_to_file(ThumbnailsGeneratorCallback &thumbnail_cb,
                         output("; bigtree thumbnail end\n");
                     }
                     else if (format == GCodeThumbnailsFormat::TFT) {
-                        // TODO
+                        // for TFT, small and big thumbnails are necessary
+                        
+                        image_tag = ";simage:"
+
+                        // if second image (big)
+                        if (image_count == 1){
+                            image_tag = ";;gimage:"
+                        }
+                        
+                        output((boost::format("\n;\n; %s begin %dx%d\n") % compressed->tag() % data.width % data.height);
+                        
+                        if (((char*)compressed->data)[compressed->size -1] == '\0')
+                            output((char*)(compressed->data));
+                        else
+                            assert(false);
+                        
+                        output("M10086 ;\n");
+
+                        image_count++;
                     } else {
                         std::string encoded;
                         encoded.resize(boost::beast::detail::base64::encoded_size(compressed->size));

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -292,7 +292,8 @@ static const t_config_enum_values s_keys_map_GCodeThumbnailsFormat = {
     { "PNG", int(GCodeThumbnailsFormat::PNG) },
     { "JPG", int(GCodeThumbnailsFormat::JPG) },
     { "QOI", int(GCodeThumbnailsFormat::QOI) },
-    { "BIQU", int(GCodeThumbnailsFormat::BIQU) }
+    { "BIQU", int(GCodeThumbnailsFormat::BIQU) },
+    { "TFT", int(GCodeThumbnailsFormat::TFT) }
 };
 CONFIG_OPTION_ENUM_DEFINE_STATIC_MAPS(GCodeThumbnailsFormat)
 
@@ -413,10 +414,12 @@ void PrintConfigDef::init_common_params()
     def->enum_values.push_back("JPG");
     def->enum_values.push_back("QOI");
     def->enum_values.push_back("BIQU");
+    def->enum_values.push_back("TFT");
     def->enum_labels.push_back("PNG");
     def->enum_labels.push_back("JPG");
     def->enum_labels.push_back("QOI");
     def->enum_labels.push_back("Biqu");
+    def->enum_labels.push_back("TFT");
     def->set_default_value(new ConfigOptionEnum<GCodeThumbnailsFormat>(GCodeThumbnailsFormat::PNG));
 
     def = this->add("thumbnails_with_support", coBool);

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -252,7 +252,7 @@ enum DraftShield {
 };
 
 enum class GCodeThumbnailsFormat {
-    PNG, JPG, QOI, BIQU
+    PNG, JPG, QOI, BIQU, TFT
 };
 
 enum ZLiftTop {


### PR DESCRIPTION
Implementation of MKS TFT thumbnails for other printers than Biqu.
I was inspired by this PR https://github.com/ArtificalSUN/MKS-WIFI_PS_uploader/pull/5 but I don't have much experience in c++.

I would like to get some help to convert the logic that can be found here:
https://github.com/Jeredian/mks-wifi-plugin/blob/develop/MKSPreview.py#L21
and here
https://github.com/SH1NZ33/MKS-WIFI_PS_uploader/blob/patch-1/MKS_WIFI_PS_upload.pyw#L31

For the moment I copied the conversion from Biqu.
The sections that need to be checked and edited are:
- https://github.com/adripo/SuperSlicer/blob/tft-thumbnails/src/libslic3r/GCode/Thumbnails.hpp#L59 from 59 to 78
- https://github.com/adripo/SuperSlicer/blob/tft-thumbnails/src/libslic3r/GCode/Thumbnails.cpp#L84 from 84 to 119


