### PR TITLE
Cool internal perimeters as external.

### DIFF
--- a/resources/ui_layout/default/filament.ui
+++ b/resources/ui_layout/default/filament.ui
@@ -36,7 +36,10 @@ group:Fan speed - default
 		setting:label$Infill bridges:bridge_internal_fan_speed
 	end_line
 	setting:top_fan_speed
-	setting:external_perimeter_fan_speed
+	line:External perimeter fan speed
+		setting:label$:external_perimeter_fan_speed
+		setting:label$Internal as external:internal_perimeter_fan_as_external
+	end_line
 	setting:support_material_interface_fan_speed
 	line:Disable fan for the first
 		setting:label$_:sidetext_width$12:disable_fan_first_layers

--- a/resources/ui_layout/example/filament.ui
+++ b/resources/ui_layout/example/filament.ui
@@ -36,7 +36,10 @@ group:Fan speed - default
 		setting:label$Infill bridges:bridge_internal_fan_speed
 	end_line
 	setting:top_fan_speed
-	setting:external_perimeter_fan_speed
+	line:External perimeter fan speed
+		setting:label$:external_perimeter_fan_speed
+		setting:label$Internal as external:internal_perimeter_fan_as_external
+	end_line
 	setting:support_material_interface_fan_speed
 	line:Disable fan for the first
 		setting:label$_:sidetext_width$12:disable_fan_first_layers

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5167,6 +5167,8 @@ std::string GCode::_before_extrude(const ExtrusionPath &path, const std::string 
             comment += ";_EXTERNAL_PERIMETER";
         if (path.role() == erThinWall)
             comment += ";_EXTERNAL_PERIMETER";
+        if (BOOL_EXTRUDER_CONFIG(internal_perimeter_fan_as_external) && path.role() == erPerimeter)
+            comment += ";_EXTERNAL_PERIMETER";
     }
     // F     is mm per minute.
     // speed is mm per second

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -750,6 +750,7 @@ static std::vector<std::string> s_Preset_filament_options {
         "min_print_speed",
         "start_filament_gcode", "end_filament_gcode",
         "external_perimeter_fan_speed",
+        "internal_perimeter_fan_as_external",
         // Retract overrides
         "filament_retract_length", "filament_retract_lift", "filament_retract_lift_above", "filament_retract_lift_below", "filament_retract_speed", "filament_deretract_speed", "filament_retract_restart_extra", "filament_retract_before_travel",
         "filament_retract_layer_change", "filament_retract_before_wipe", 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -85,6 +85,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver& /* ne
         "external_perimeter_acceleration",
         "external_perimeter_cut_corners",
         "external_perimeter_fan_speed",
+        "internal_perimeter_fan_as_external",
         "extrusion_axis",
         "extruder_clearance_height",
         "extruder_clearance_radius",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -1490,6 +1490,14 @@ void PrintConfigDef::init_fff_params()
     def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionInts { -1 });
 
+    def = this->add("internal_perimeter_fan_as_external", coBools);
+    def->label = L("Cool internal perimeter as external");
+    def->category = OptionCategory::cooling;
+    def->tooltip = L("If this is enabled, internal perimeters will be cooled as external");
+    def->mode = comAdvancedE | comSuSi;
+    def->is_vector_extruder = true;
+    def->set_default_value(new ConfigOptionBools{ false });
+
     def = this->add("external_perimeter_overlap", coPercent);
     def->label = L("external perimeter overlap");
     def->full_label = L("Ext. peri. overlap");
@@ -7434,6 +7442,7 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "external_perimeter_cut_corners",
 "external_perimeter_extrusion_spacing",
 "external_perimeter_fan_speed",
+"perimeters_fan_as_external",
 "external_perimeter_overlap",
 "external_perimeters_hole",
 "external_perimeters_nothole",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1139,6 +1139,7 @@ PRINT_CONFIG_CLASS_DERIVED_DEFINE(
     ((ConfigOptionBool,                 enforce_retract_first_layer))
     ((ConfigOptionFloatOrPercent,       external_perimeter_acceleration))
     ((ConfigOptionInts,                 external_perimeter_fan_speed))
+    ((ConfigOptionBools,                internal_perimeter_fan_as_external))
     ((ConfigOptionFloat,                extruder_clearance_height))
     ((ConfigOptionFloat,                extruder_clearance_radius))
     ((ConfigOptionStrings,              extruder_colour))


### PR DESCRIPTION
PR for #3408 

It could further improve model stability in case when infill not cooled. 

![image](https://user-images.githubusercontent.com/8691781/200596957-dd7ac343-b5ff-4515-a86a-2c211060b82c.png)

![image](https://user-images.githubusercontent.com/8691781/200596991-ea65c80c-cff2-4cb6-a2fe-64affca1e47a.png)
