### PR TITLE
Some Windows/RDP related issues fixes

### DIFF
--- a/src/PrusaSlicer_app_msvc.cpp
+++ b/src/PrusaSlicer_app_msvc.cpp
@@ -234,13 +234,14 @@ int wmain(int argc, wchar_t **argv)
 #ifdef SLIC3R_GUI
     // Here one may push some additional parameters based on the wrapper type.
     bool force_mesa = false;
+    bool force_hw   = false;
 #endif /* SLIC3R_GUI */
     for (int i = 1; i < argc; ++ i) {
 #ifdef SLIC3R_GUI
         if (wcscmp(argv[i], L"--sw-renderer") == 0)
             force_mesa = true;
         else if (wcscmp(argv[i], L"--no-sw-renderer") == 0)
-            force_mesa = false;
+            force_hw = true;
 #endif /* SLIC3R_GUI */
         argv_extended.emplace_back(argv[i]);
     }
@@ -253,7 +254,7 @@ int wmain(int argc, wchar_t **argv)
         force_mesa ||
         // Running over a rempote desktop, and the RemoteFX is not enabled, therefore Windows will only provide SW OpenGL 1.1 context.
         // In that case, use Mesa.
-        ::GetSystemMetrics(SM_REMOTESESSION) ||
+        (::GetSystemMetrics(SM_REMOTESESSION) && !force_hw) ||
         // Try to load the default OpenGL driver and test its context version.
         ! opengl_version_check.load_opengl_dll() || ! opengl_version_check.is_version_greater_or_equal_to(2, 0);
 #endif /* SLIC3R_GUI */

--- a/src/slic3r/GUI/Mouse3DController.cpp
+++ b/src/slic3r/GUI/Mouse3DController.cpp
@@ -670,6 +670,11 @@ void Mouse3DController::init()
 #ifndef _WIN32
     	// Don't start the background thread on Windows, as the HID messages are sent as Windows messages.
 	    m_thread = std::thread(&Mouse3DController::run, this);
+#else
+        // For some reason, HID message routing does not work well with remote session. Requires further investigation
+        if (::GetSystemMetrics(SM_REMOTESESSION)) {
+            m_thread = std::thread(&Mouse3DController::run, this);
+        }
 #endif // _WIN32
 	}
 }


### PR DESCRIPTION
Please review these 2 changes.
1. Small change around `--sw-render`, `--no-sw-render` flags: till now `--no-sw-render` had no effect, because it anyway was a default state. Now `--no-sw-render` allows to force using HW rendering even on windows remote session. Actually I don't understand why to check explicitly whether it's remote session or not. According to the comment, this check was introduced because on remote session OpenGL 1.1 was provided, but there is anyway additional check of OpenGL version, so why checking the version only is not enough? Anyway, Windows allows configuring Remote Session Host to use host's HW GPU for remote sessions. In such configuration the HW backed OpenGL is fully available and there is no reason not to allow using it in remote session. 

I think the correct solution would be to remote session check when deciding whether to use mesa or not, but meanwhile I allowed at least forcing it using the command line `--no-sw-render`


2. 3DConnexion does not work in remote session. After investigation - saw that in remote session, WM handler, which was registered in `MainFrame.cpp` by using `wxWindow::MSWRegisterMessageHandler(WM_INPUT, ...)` is never called. This callback was introduced in commit 25d58faaad5240c2f2985ca2a9c89e6b8617a2b1 and it had to replace the usage of dedicated 3DConnexion polling thread. My change reenables the polling thread only in in windows remote session. This solves 3DConnexion issue on this setup

Let me know if there is a need to rework, my fixes or/and to split them into separate PRs