### PR TITLE
Add a speed knob to the wipe tower.

### DIFF
--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -286,6 +286,8 @@ group:label_width$8:sidetext_width$7:Speed for print moves
 	line:Other speed
 		setting:width$4:thin_walls_speed
 		setting:width$4:ironing_speed
+		setting:wipe_tower_speed
+		setting:wipe_tower_wipe_starting_speed
 group:Speed for non-print moves
 	line:Travel speed
 		setting:label$xy:travel_speed

--- a/src/libslic3r/GCode/WipeTower.cpp
+++ b/src/libslic3r/GCode/WipeTower.cpp
@@ -196,7 +196,7 @@ public:
 	}
 
 	WipeTowerWriter& extrude_explicit(const Vec2f &dest, float e, float f = 0.f, bool record_length = false, bool limit_volumetric_flow = true)
-		{ return extrude_explicit(dest.x(), dest.y(), e, f, record_length); }
+		{ return extrude_explicit(dest.x(), dest.y(), e, f, record_length, limit_volumetric_flow); }
 
 	// Travel to a new XY position. f=0 means use the current value.
 	WipeTowerWriter& travel(float x, float y, float f = 0.f)
@@ -633,6 +633,8 @@ WipeTower::WipeTower(const PrintConfig& config, const PrintObjectConfig& default
     m_wipe_tower_pos(config.wipe_tower_x, config.wipe_tower_y),
     m_wipe_tower_width(float(config.wipe_tower_width)),
     m_wipe_tower_rotation_angle(float(config.wipe_tower_rotation_angle)),
+    m_speed(float(config.wipe_tower_speed)),
+    m_wipe_starting_speed(config.wipe_tower_wipe_starting_speed),
     m_y_shift(0.f),
     m_z_pos(0.f),
     m_bridging(float(config.wipe_tower_bridging)),
@@ -642,13 +644,15 @@ WipeTower::WipeTower(const PrintConfig& config, const PrintObjectConfig& default
     m_current_tool(initial_tool),
     wipe_volumes(wiping_matrix)
 {
+    // Wipe starting speed defaults to wipe_tower_speed.
+    if (m_wipe_starting_speed == 0.f) {
+        m_wipe_starting_speed = m_speed;
+    }
     // Read absolute value of first layer speed, if given as percentage,
-    // it is taken over following default. Speeds from config are not
-    // easily accessible here.
-    const float default_speed = 60.f;
-    m_first_layer_speed = config.get_abs_value("first_layer_speed", default_speed);
-    if (m_first_layer_speed == 0.f) // just to make sure autospeed doesn't break it.
-        m_first_layer_speed = default_speed / 2.f;
+    // it is taken over wipe_tower_speed.
+    m_first_layer_speed = config.get_abs_value("first_layer_speed", m_speed);
+    if (m_first_layer_speed == 0.f)
+        m_first_layer_speed = m_speed;
 
     // If this is a single extruder MM printer, we will use all the SE-specific config values.
     // Otherwise, the defaults will be used to turn off the SE stuff.
@@ -1245,11 +1249,12 @@ void WipeTower::toolchange_Wipe(
     //   the ordered volume, even if it means violating the box. This can later be removed and simply
     // wipe until the end of the assigned area.
 
-	float x_to_wipe = volume_to_length(wipe_volume, m_perimeter_width, m_layer_height);
+	const float x_wipe_target = volume_to_length(wipe_volume, m_perimeter_width, m_layer_height);
+    float x_wiped = 0.f;
 	float dy = m_extra_spacing*m_perimeter_width;
 
-    const float target_speed = is_first_layer() ? m_first_layer_speed * 60.f : 4800.f;
-    float wipe_speed = 0.33f * target_speed;
+    const float target_speed = (is_first_layer() ? m_first_layer_speed : m_speed) * 60.f;
+    float wipe_speed = (m_wipe_starting_speed < target_speed ? m_wipe_starting_speed : target_speed) * 60.f;
     if (this->m_config->filament_max_speed.get_at(this->m_current_tool) > 0) {
         wipe_speed = std::min(wipe_speed, float(this->m_config->filament_max_speed.get_at(this->m_current_tool)) * 60.f); // mm/s -> mm/min
     }
@@ -1269,7 +1274,7 @@ void WipeTower::toolchange_Wipe(
             else wipe_speed = std::min(target_speed, wipe_speed + 50.f);
 		}
 
-		float traversed_x = writer.x();
+		const float x_start = writer.x();
 		if (m_left_to_right)
             writer.extrude(xr - (i % 4 == 0 ? 0 : 1.5f*m_perimeter_width), writer.y(), wipe_speed * speed_factor);
 		else
@@ -1278,9 +1283,9 @@ void WipeTower::toolchange_Wipe(
         if (writer.y()+float(EPSILON) > cleaning_box.lu.y()-0.5f*m_perimeter_width)
             break;		// in case next line would not fit
 
-		traversed_x -= writer.x();
-        x_to_wipe -= std::abs(traversed_x);
-		if (x_to_wipe < WT_EPSILON) {
+		const float traversed_x = x_start - writer.x();
+        x_wiped += std::abs(traversed_x);
+		if ((x_wiped + WT_EPSILON) >= x_wipe_target) {
             writer.travel(m_left_to_right ? xl + 1.5f*m_perimeter_width : xr - 1.5f*m_perimeter_width, writer.y(), 7200);
 			break;
 		}
@@ -1321,7 +1326,7 @@ WipeTower::ToolChangeResult WipeTower::finish_layer()
 	// Slow down on the 1st layer.
     bool first_layer = is_first_layer();
 	float speed_factor = 1.f;
-    float feedrate = first_layer ? m_first_layer_speed * 60.f : 2900.f;
+    float feedrate = first_layer ? m_first_layer_speed * 60.f : m_speed * 60.f;
     speed_factor *= get_speed_reduction();
 	float current_depth = m_layer_info->depth - m_layer_info->toolchanges_depth();
     box_coordinates fill_box(Vec2f(m_perimeter_width, m_layer_info->depth-(current_depth-m_perimeter_width)),

--- a/src/libslic3r/GCode/WipeTower.hpp
+++ b/src/libslic3r/GCode/WipeTower.hpp
@@ -278,8 +278,10 @@ private:
 	size_t m_max_color_changes 	= 0; 	// Maximum number of color changes per layer.
     int    m_old_temperature    = -1;   // To keep track of what was the last temp that we set (so we don't issue the command when not neccessary)
     float  m_travel_speed       = 0.f;
-    float  m_first_layer_speed  = 0.f;
+    float  m_first_layer_speed  = 0.f;   // First layer speed in mm/s.
     size_t m_first_layer_idx    = size_t(-1);
+	float  m_speed              = 0.f;  // Wipe tower speed in mm/s.
+	float  m_wipe_starting_speed = 0.f; // Starting speed during wipe, up to m_speed.
 
 	// G-code generator parameters.
     float           m_cooling_tube_retraction   = 0.f;

--- a/src/libslic3r/Preset.cpp
+++ b/src/libslic3r/Preset.cpp
@@ -653,6 +653,7 @@ static std::vector<std::string> s_Preset_print_options {
         "threads",
         // wipe tower
         "wipe_tower", "wipe_tower_x", "wipe_tower_y", "wipe_tower_width", "wipe_tower_rotation_angle", "wipe_tower_bridging",
+        "wipe_tower_speed", "wipe_tower_wipe_starting_speed",
         "wipe_tower_brim_width",
         "mmu_segmented_region_max_width",
         "single_extruder_multi_material_priming", 

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -297,6 +297,8 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver& /* ne
             || opt_key == "wipe_tower_brim_width"
             || opt_key == "wipe_tower_bridging"
             || opt_key == "wipe_tower_no_sparse_layers"
+            || opt_key == "wipe_tower_speed"
+            || opt_key == "wipe_tower_wipe_starting_speed"
             || opt_key == "wiping_volumes_matrix"
             || opt_key == "parking_pos_retraction"
             || opt_key == "cooling_tube_retraction"

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -5243,6 +5243,20 @@ void PrintConfigDef::init_fff_params()
     def->mode = comExpert | comSuSi;
     def->set_default_value(new ConfigOptionFloatOrPercent(100, true));
 
+    def = this->add("wipe_tower_speed", coFloat);
+    def->label = L("Speed");
+    def->tooltip = L("Printing speed of the wipe tower. Capped by filament_max_volumetric_speed (if set).");
+    def->sidetext = L("mm/s");
+    def->mode = comAdvancedE | comPrusa;
+    def->set_default_value(new ConfigOptionFloat(80.));
+
+    def = this->add("wipe_tower_wipe_starting_speed", coFloat);
+    def->label = L("Wipe starting speed");
+    def->tooltip = L("Start of the wiping speed ramp up. Set to 0 to disable.");
+    def->sidetext = L("mm/s");
+    def->mode = comAdvancedE | comPrusa;
+    def->set_default_value(new ConfigOptionFloat(26.));
+
     def = this->add("threads", coInt);
     def->label = L("Threads");
     def->tooltip = L("Threads are used to parallelize long-running tasks. Optimal threads number "

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1033,6 +1033,8 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionBool,                single_extruder_multi_material))
     ((ConfigOptionBool,                single_extruder_multi_material_priming))
     ((ConfigOptionBool,                wipe_tower_no_sparse_layers))
+    ((ConfigOptionFloat,               wipe_tower_speed))
+    ((ConfigOptionFloat,               wipe_tower_wipe_starting_speed))
     ((ConfigOptionStrings,             tool_name))
     ((ConfigOptionString,              toolchange_gcode))
     ((ConfigOptionFloat,               travel_speed))

--- a/src/slic3r/GUI/ConfigManipulation.cpp
+++ b/src/slic3r/GUI/ConfigManipulation.cpp
@@ -502,7 +502,7 @@ void ConfigManipulation::toggle_print_fff_options(DynamicPrintConfig* config)
 
     bool have_wipe_tower = config->opt_bool("wipe_tower");
     for (auto el : { "wipe_tower_x", "wipe_tower_y", "wipe_tower_width", "wipe_tower_rotation_angle", "wipe_tower_brim_width",
-                     "wipe_tower_bridging", "wipe_tower_brim", "wipe_tower_no_sparse_layers", "single_extruder_multi_material_priming" })
+                     "wipe_tower_bridging", "wipe_tower_brim", "wipe_tower_no_sparse_layers", "single_extruder_multi_material_priming", "wipe_tower_speed", "wipe_tower_wipe_starting_speed" })
         toggle_field(el, have_wipe_tower);
 
     bool have_avoid_crossing_perimeters = config->opt_bool("avoid_crossing_perimeters");

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2046,6 +2046,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         "skirt_extrusion_width", "skirt_height",
         "variable_layer_height", "nozzle_diameter", "single_extruder_multi_material",
         "wipe_tower", "wipe_tower_brim_width", "wipe_tower_rotation_angle", "wipe_tower_width", "wipe_tower_x", "wipe_tower_y",
+        "wipe_tower_speed", "wipe_tower_wipe_starting_speed",
         "extruder_colour", "filament_colour", "material_colour",
         "printer_model", "printer_technology",
         // These values are necessary to construct SlicingParameters by the Canvas3D variable layer height editor.


### PR DESCRIPTION
The default for wipe_tower_speed is 80mm/s which was hardcoded before. The perimeter and grid section of the wipe tower will also print at wipe_tower_speed. Though before it was hardcoded independently at 60mm/s.

wipe_tower_wipe_starting_speed is set to 26mm/s by default. And uses the same ramp up logic as before. Ramping up the speed of the wipe lines with an aggressive curve, before moving linearly 0.8mm/s at a time.

wipe_tower_wipe_starting_speed can be turned of by setting to 0.

The wipe_tower_speed is capped by the filament_max_volumetric_speed. If filament_max_volumetric_speed is not set (0 value), then there is no cap.

I personally only set a filament_max_volumetric_speed on stuff like very flexible TPU and what not. For the rest, I depend on the global volumetric speed limit. This way, I can set the wipe tower speed to exceed my normal printing flow rate since quality of the wipe tower doesn't matter. But a low flow rate filament would still be capped by filament_max_volumetric_speed, preventing a mess.

Using https://github.com/bombela/PrusaSlicer/commit/3fbe811b8b2ff7d780b0e17246c38dcf50d93c42