### PR TITLE
Add max layer height to adaptive layers

### DIFF
--- a/src/libslic3r/Slicing.cpp
+++ b/src/libslic3r/Slicing.cpp
@@ -363,7 +363,7 @@ std::vector<coordf_t> layer_height_profile_from_ranges(
 
 // Based on the work of @platsch
 // Fill layer_height_profile by heights ensuring a prescribed maximum cusp height.
-std::vector<double> layer_height_profile_adaptive(const SlicingParameters& slicing_params, const ModelObject& object, float quality_factor)
+std::vector<double> layer_height_profile_adaptive(const SlicingParameters& slicing_params, const ModelObject& object, float quality_factor, float max_adaptive_layer_height)
 {
     // 1) Initialize the SlicingAdaptive class with the object meshes.
     SlicingAdaptive as;
@@ -383,7 +383,7 @@ std::vector<double> layer_height_profile_adaptive(const SlicingParameters& slici
     size_t current_facet = 0;
     // loop until we have at least one layer and the max slice_z reaches the object height
     while (print_z + EPSILON < slicing_params.object_print_z_height()) {
-        coordf_t height = slicing_params.max_layer_height;
+        coordf_t height = std::min(slicing_params.max_layer_height, (coordf_t)max_adaptive_layer_height);
         // Slic3r::debugf "\n Slice layer: %d\n", $id;
         // determine next layer height
         float cusp_height = as.next_layer_height(float(print_z), quality_factor, current_facet);

--- a/src/libslic3r/Slicing.hpp
+++ b/src/libslic3r/Slicing.hpp
@@ -145,7 +145,7 @@ extern std::vector<coordf_t> layer_height_profile_from_ranges(
 
 extern std::vector<double> layer_height_profile_adaptive(
     const SlicingParameters& slicing_params,
-    const ModelObject& object, float quality_factor);
+    const ModelObject& object, float quality_factor, float max_adaptive_layer_height);
 
 struct HeightProfileSmoothingParams
 {
@@ -155,6 +155,16 @@ struct HeightProfileSmoothingParams
     HeightProfileSmoothingParams() : radius(5), keep_min(false) {}
     HeightProfileSmoothingParams(unsigned int radius, bool keep_min) : radius(radius), keep_min(keep_min) {}
 };
+
+struct HeightProfileAdaptiveParams
+{
+    float adaptive_quality;
+    float max_adaptive_layer_height;
+
+    HeightProfileAdaptiveParams() : adaptive_quality(0.5f), max_adaptive_layer_height(0.3f) {}
+    HeightProfileAdaptiveParams(float adaptive_quality, float max_adaptive_layer_height) : adaptive_quality(adaptive_quality), max_adaptive_layer_height(max_adaptive_layer_height) {}
+};
+
 
 extern std::vector<double> smooth_height_profile(
     const std::vector<double>& profile, const SlicingParameters& slicing_params,

--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -246,7 +246,7 @@ void GLCanvas3D::LayersEditing::render_overlay(const GLCanvas3D& canvas) const
     
     ImGui::Separator();
     if (imgui.button(_L("Adaptive")))
-        wxPostEvent((wxEvtHandler*)canvas.get_wxglcanvas(), Event<float>(EVT_GLCANVAS_ADAPTIVE_LAYER_HEIGHT_PROFILE, m_adaptive_quality));
+        wxPostEvent((wxEvtHandler*)canvas.get_wxglcanvas(), HeightProfileAdaptiveEvent(EVT_GLCANVAS_ADAPTIVE_LAYER_HEIGHT_PROFILE, m_adaptive_params));
 
     ImGui::SameLine();
     float text_align = ImGui::GetCursorPosX();
@@ -261,8 +261,22 @@ void GLCanvas3D::LayersEditing::render_overlay(const GLCanvas3D& canvas) const
     ImGui::SameLine();
     float widget_align = ImGui::GetCursorPosX();
     ImGui::PushItemWidth(imgui.get_style_scaling() * 120.0f);
-    m_adaptive_quality = std::clamp(m_adaptive_quality, 0.0f, 1.f);
-    imgui.slider_float("", &m_adaptive_quality, 0.0f, 1.f, "%.2f");
+    m_adaptive_params.adaptive_quality = std::clamp(m_adaptive_params.adaptive_quality, 0.0f, 1.f);
+    imgui.slider_float("", &m_adaptive_params.adaptive_quality, 0.0f, 1.f, "%.2f");
+
+    ImGui::SetCursorPosX(text_align);
+    ImGui::AlignTextToFramePadding();
+    imgui.text(_L("Max layer height"));
+    if (ImGui::IsItemHovered()) {
+        ImGui::BeginTooltip();
+        ImGui::TextUnformatted(_L("Maximum layer height. Limit for better quality/layer adhesion.").ToUTF8());
+        ImGui::EndTooltip();
+    }
+
+    ImGui::SameLine();
+    ImGui::SetCursorPosX(widget_align);
+    ImGui::PushItemWidth(imgui.get_style_scaling() * 120.0f);
+    ImGui::SliderFloat("", &m_adaptive_params.max_adaptive_layer_height, 0.1f, 0.5f, "%.2f");
 
     ImGui::Separator();
     if (imgui.button(_L("Smooth")))
@@ -508,10 +522,10 @@ void GLCanvas3D::LayersEditing::reset_layer_height_profile(GLCanvas3D& canvas)
     wxGetApp().obj_list()->update_info_items(last_object_id);
 }
 
-void GLCanvas3D::LayersEditing::adaptive_layer_height_profile(GLCanvas3D& canvas, float quality_factor)
+void GLCanvas3D::LayersEditing::adaptive_layer_height_profile(GLCanvas3D& canvas, float quality_factor, float max_adaptive_layer_height)
 {
     this->update_slicing_parameters();
-    m_layer_height_profile = layer_height_profile_adaptive(*m_slicing_parameters, *m_model_object, quality_factor);
+    m_layer_height_profile = layer_height_profile_adaptive(*m_slicing_parameters, *m_model_object, quality_factor, max_adaptive_layer_height);
     const_cast<ModelObject*>(m_model_object)->layer_height_profile.set(m_layer_height_profile);
     m_layers_texture.valid = false;
     canvas.post_event(SimpleEvent(EVT_GLCANVAS_SCHEDULE_BACKGROUND_PROCESS));
@@ -905,7 +919,7 @@ wxDEFINE_EVENT(EVT_GLCANVAS_UNDO, SimpleEvent);
 wxDEFINE_EVENT(EVT_GLCANVAS_REDO, SimpleEvent);
 wxDEFINE_EVENT(EVT_GLCANVAS_COLLAPSE_SIDEBAR, SimpleEvent);
 wxDEFINE_EVENT(EVT_GLCANVAS_RESET_LAYER_HEIGHT_PROFILE, SimpleEvent);
-wxDEFINE_EVENT(EVT_GLCANVAS_ADAPTIVE_LAYER_HEIGHT_PROFILE, Event<float>);
+wxDEFINE_EVENT(EVT_GLCANVAS_ADAPTIVE_LAYER_HEIGHT_PROFILE, HeightProfileAdaptiveEvent);
 wxDEFINE_EVENT(EVT_GLCANVAS_SMOOTH_LAYER_HEIGHT_PROFILE, HeightProfileSmoothEvent);
 wxDEFINE_EVENT(EVT_GLCANVAS_RELOAD_FROM_DISK, SimpleEvent);
 wxDEFINE_EVENT(EVT_GLCANVAS_RENDER_TIMER, wxTimerEvent/*RenderTimerEvent*/);
@@ -1336,10 +1350,10 @@ void GLCanvas3D::reset_layer_height_profile()
     }
 }
 
-void GLCanvas3D::adaptive_layer_height_profile(float quality_factor)
+void GLCanvas3D::adaptive_layer_height_profile(const HeightProfileAdaptiveParams& adaptive_params)
 {
     wxGetApp().plater()->take_snapshot(_L("Variable layer height - Adaptive"));
-    m_layers_editing.adaptive_layer_height_profile(*this, quality_factor);
+    m_layers_editing.adaptive_layer_height_profile(*this, adaptive_params.adaptive_quality, adaptive_params.max_adaptive_layer_height);
     m_layers_editing.state = LayersEditing::Completed;
     m_dirty = true;
 }

--- a/src/slic3r/GUI/GLCanvas3D.hpp
+++ b/src/slic3r/GUI/GLCanvas3D.hpp
@@ -145,6 +145,7 @@ using Vec3dEvent = Event<Vec3d>;
 template <size_t N> using Vec3dsEvent = ArrayEvent<Vec3d, N>;
 
 using HeightProfileSmoothEvent = Event<HeightProfileSmoothingParams>;
+using HeightProfileAdaptiveEvent = Event<HeightProfileAdaptiveParams>;
 
 wxDECLARE_EVENT(EVT_GLCANVAS_SCHEDULE_BACKGROUND_PROCESS, SimpleEvent);
 wxDECLARE_EVENT(EVT_GLCANVAS_RIGHT_CLICK, RBtnEvent);
@@ -173,7 +174,7 @@ wxDECLARE_EVENT(EVT_GLCANVAS_UNDO, SimpleEvent);
 wxDECLARE_EVENT(EVT_GLCANVAS_REDO, SimpleEvent);
 wxDECLARE_EVENT(EVT_GLCANVAS_COLLAPSE_SIDEBAR, SimpleEvent);
 wxDECLARE_EVENT(EVT_GLCANVAS_RESET_LAYER_HEIGHT_PROFILE, SimpleEvent);
-wxDECLARE_EVENT(EVT_GLCANVAS_ADAPTIVE_LAYER_HEIGHT_PROFILE, Event<float>);
+wxDECLARE_EVENT(EVT_GLCANVAS_ADAPTIVE_LAYER_HEIGHT_PROFILE, HeightProfileAdaptiveEvent);
 wxDECLARE_EVENT(EVT_GLCANVAS_SMOOTH_LAYER_HEIGHT_PROFILE, HeightProfileSmoothEvent);
 wxDECLARE_EVENT(EVT_GLCANVAS_RELOAD_FROM_DISK, SimpleEvent);
 wxDECLARE_EVENT(EVT_GLCANVAS_RENDER_TIMER, wxTimerEvent/*RenderTimerEvent*/);
@@ -211,7 +212,7 @@ class GLCanvas3D
         std::vector<double>         m_layer_height_profile;
         bool                        m_layer_height_profile_modified{ false };
 
-        mutable float               m_adaptive_quality{ 0.5f };
+        mutable HeightProfileAdaptiveParams m_adaptive_params;
         mutable HeightProfileSmoothingParams m_smooth_params;
         
         static float                s_overlay_window_width;
@@ -260,7 +261,7 @@ class GLCanvas3D
 		void adjust_layer_height_profile();
 		void accept_changes(GLCanvas3D& canvas);
         void reset_layer_height_profile(GLCanvas3D& canvas);
-        void adaptive_layer_height_profile(GLCanvas3D& canvas, float quality_factor);
+        void adaptive_layer_height_profile(GLCanvas3D& canvas, float quality_factor, float max_adaptive_layer_height);
         void smooth_layer_height_profile(GLCanvas3D& canvas, const HeightProfileSmoothingParams& smoothing_params);
 
         static float get_cursor_z_relative(const GLCanvas3D& canvas);
@@ -680,7 +681,7 @@ public:
     bool is_search_pressed() const;
 
     void reset_layer_height_profile();
-    void adaptive_layer_height_profile(float quality_factor);
+    void adaptive_layer_height_profile(const HeightProfileAdaptiveParams& adaptive_params);
     void smooth_layer_height_profile(const HeightProfileSmoothingParams& smoothing_params);
 
     bool is_reload_delayed() const;

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -2152,7 +2152,7 @@ Plater::priv::priv(Plater *q, MainFrame *main_frame)
         view3D_canvas->Bind(EVT_GLCANVAS_REDO, [this](SimpleEvent&) { this->redo(); });
         view3D_canvas->Bind(EVT_GLCANVAS_COLLAPSE_SIDEBAR, [this](SimpleEvent&) { this->q->collapse_sidebar(!this->q->is_sidebar_collapsed());  });
         view3D_canvas->Bind(EVT_GLCANVAS_RESET_LAYER_HEIGHT_PROFILE, [this](SimpleEvent&) { this->view3D->get_canvas3d()->reset_layer_height_profile(); });
-        view3D_canvas->Bind(EVT_GLCANVAS_ADAPTIVE_LAYER_HEIGHT_PROFILE, [this](Event<float>& evt) { this->view3D->get_canvas3d()->adaptive_layer_height_profile(evt.data); });
+        view3D_canvas->Bind(EVT_GLCANVAS_ADAPTIVE_LAYER_HEIGHT_PROFILE, [this](HeightProfileAdaptiveEvent& evt) { this->view3D->get_canvas3d()->adaptive_layer_height_profile(evt.data); });
         view3D_canvas->Bind(EVT_GLCANVAS_SMOOTH_LAYER_HEIGHT_PROFILE, [this](HeightProfileSmoothEvent& evt) { this->view3D->get_canvas3d()->smooth_layer_height_profile(evt.data); });
         view3D_canvas->Bind(EVT_GLCANVAS_RELOAD_FROM_DISK, [this](SimpleEvent&) { this->reload_all_from_disk(); });
 


### PR DESCRIPTION
Add maximum layer height to adaptive layers dialog. Currently it's limited by extruder(s) max layer height, but in some situation it's desirable to limit it more, for example for better layers adhesion and strength.

Range is hardcoded 0.1-0.5, as I didn't succeed to get access to max_layer_height in Printer config, but I guess it's enough.

![image](https://user-images.githubusercontent.com/8691781/213760714-95e441b3-e536-44c8-848a-5688b15f3b28.png)

![image](https://user-images.githubusercontent.com/8691781/213760820-da3c9bdd-c68a-4497-9bf9-f0099ce4d86b.png)
