### PR TITLE
Add option to avoid Z lift for short travel moves

### DIFF
--- a/resources/ui_layout/default/extruder.ui
+++ b/resources/ui_layout/default/extruder.ui
@@ -22,6 +22,7 @@ group:Retraction
 		setting:idx:retract_lift_first_layer
 		setting:idx:retract_lift_top
 	end_line
+	setting:idx:retract_lift_before_travel
 	line:Retraction Speed
 		setting:idx:retract_speed
 		setting:idx:label$Deretraction:deretract_speed

--- a/resources/ui_layout/example/extruder.ui
+++ b/resources/ui_layout/example/extruder.ui
@@ -21,6 +21,7 @@ group:Retraction
 	line:Lift z enforcement
 		setting:idx:retract_lift_first_layer
 		setting:idx:retract_lift_top
+		setting:idx:retract_lift_before_travel
 	end_line
 	line:Retraction Speed
 		setting:idx:retract_speed

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5784,7 +5784,10 @@ Polyline GCode::travel_to(std::string &gcode, const Point &point, ExtrusionRole 
         }
 
         Point last_post_before_retract = this->last_pos();
-        gcode += this->retract();
+
+        bool no_lift_on_retract = travel.length() <= scale_(EXTRUDER_CONFIG_WITH_DEFAULT(retract_lift_before_travel, 0));
+        gcode += this->retract(false, no_lift_on_retract);
+
         // When "Wipe while retracting" is enabled, then extruder moves to another position, and travel from this position can cross perimeters.
         bool updated_first_pos = false;
         if (last_post_before_retract != this->last_pos() && can_avoid_cross_peri) {
@@ -5956,7 +5959,7 @@ bool GCode::can_cross_perimeter(const Polyline& travel, bool offset)
     return true;
 }
 
-std::string GCode::retract(bool toolchange)
+std::string GCode::retract(bool toolchange, bool inhibit_lift)
 {
     std::string gcode;
 
@@ -5994,7 +5997,7 @@ std::string GCode::retract(bool toolchange)
         else
             need_lift = true;
     }
-    if (need_lift)
+    if (need_lift && !inhibit_lift)
         gcode += m_writer.lift(this->m_layer_index);
 
     return gcode;

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -386,7 +386,7 @@ private:
     void            write_travel_to(std::string& gcode, const Polyline& travel, std::string comment);
     bool            can_cross_perimeter(const Polyline& travel, bool offset);
     bool            needs_retraction(const Polyline& travel, ExtrusionRole role = erNone, coordf_t max_min_dist = 0);
-    std::string     retract(bool toolchange = false, bool no_z_lift = false);
+    std::string     retract(bool toolchange = false, bool inhibit_lift = false);
     std::string     unretract() { return m_writer.unlift() + m_writer.unretract(); }
     std::string     set_extruder(uint16_t extruder_id, double print_z, bool no_toolchange = false);
     std::string     toolchange(uint16_t extruder_id, double print_z);

--- a/src/libslic3r/GCode.hpp
+++ b/src/libslic3r/GCode.hpp
@@ -386,7 +386,7 @@ private:
     void            write_travel_to(std::string& gcode, const Polyline& travel, std::string comment);
     bool            can_cross_perimeter(const Polyline& travel, bool offset);
     bool            needs_retraction(const Polyline& travel, ExtrusionRole role = erNone, coordf_t max_min_dist = 0);
-    std::string     retract(bool toolchange = false);
+    std::string     retract(bool toolchange = false, bool no_z_lift = false);
     std::string     unretract() { return m_writer.unlift() + m_writer.unretract(); }
     std::string     set_extruder(uint16_t extruder_id, double print_z, bool no_toolchange = false);
     std::string     toolchange(uint16_t extruder_id, double print_z);

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -160,6 +160,7 @@ bool Print::invalidate_state_by_config_options(const ConfigOptionResolver& /* ne
         "retract_lift_below",
         "retract_lift_first_layer",
         "retract_lift_top",
+        "retract_lift_before_travel",
         "retract_restart_extra",
         "retract_restart_extra_toolchange",
         "retract_speed",

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4272,6 +4272,16 @@ void PrintConfigDef::init_fff_params()
     def->is_vector_extruder = true;
     def->set_default_value(new ConfigOptionFloats { 2. });
 
+    def = this->add("retract_lift_before_travel", coFloats);
+    def->label = L("Minimum travel after z lift");
+    def->category = OptionCategory::extruders;
+    def->tooltip = L("Z lift is not triggered when travel moves are shorter than this length.");
+    def->sidetext = L("mm");
+    def->mode = comAdvancedE | comPrusa;
+    def->min = 0;
+    def->is_vector_extruder = true;
+    def->set_default_value(new ConfigOptionFloats { 2. });
+
     def = this->add("retract_before_wipe", coPercents);
     def->label = L("Retract amount before wipe");
     def->category = OptionCategory::extruders;
@@ -6235,6 +6245,7 @@ void PrintConfigDef::init_extruder_option_keys()
         "retract_lift_above",
         "retract_lift_below",
         "retract_lift_first_layer",
+        "retract_lift_before_travel",
         "retract_lift_top",
         "retract_restart_extra",
         "retract_restart_extra_toolchange",
@@ -7650,6 +7661,7 @@ std::unordered_set<std::string> prusa_export_to_remove_keys = {
 "remaining_times_type",
 "retract_lift_first_layer",
 "retract_lift_top",
+"retract_lift_before_travel",
 "seam_angle_cost",
 "seam_gap",
 "seam_notch_all",

--- a/src/libslic3r/PrintConfig.hpp
+++ b/src/libslic3r/PrintConfig.hpp
@@ -1060,6 +1060,7 @@ PRINT_CONFIG_CLASS_DEFINE(
     ((ConfigOptionFloats,              retract_lift_below))
     ((ConfigOptionBools,               retract_lift_first_layer))
     ((ConfigOptionStrings,             retract_lift_top))
+    ((ConfigOptionFloats,              retract_lift_before_travel))
     ((ConfigOptionFloats,              retract_restart_extra))
     ((ConfigOptionFloats,              retract_restart_extra_toolchange))
     ((ConfigOptionFloats,              retract_speed))


### PR DESCRIPTION
This adds the option to inhibit Z lifts for short travel moves, while keeping the retractions. This is useful for "not connected" infills, especially on top layers.

More information on that can be found here: https://ellis3dp.com/Print-Tuning-Guide/articles/troubleshooting/small_infill_areas_overextruded.html#the-magic-bullet

Thanks to @AndrewEllis93 for the idea and the code contribution for the UI elements.