### PR TITLE
Apply small perimeters speed also to small radius parts with arc fitting.

### DIFF
--- a/resources/ui_layout/default/print.ui
+++ b/resources/ui_layout/default/print.ui
@@ -343,7 +343,7 @@ group:sidetext_width$7:Modifiers
 		setting:label_width$8:width$4:first_layer_infill_speed
 		setting:label_width$8:width$4:label$Over raft:first_layer_speed_over_raft
 	end_line
-	line:Small perimeter speed
+	line:Small perimeter/radius speed
 		setting:label_width$8:width$4:small_perimeter_speed
 		setting:label_width$8:width$4:small_perimeter_min_length
 		setting:label_width$8:width$4:small_perimeter_max_length

--- a/resources/ui_layout/example/print.ui
+++ b/resources/ui_layout/example/print.ui
@@ -342,7 +342,7 @@ group:sidetext_width$7:Modifiers
 		setting:label_width$8:width$4:first_layer_infill_speed
 		setting:label_width$8:width$4:label$Over raft:first_layer_speed_over_raft
 	end_line
-	line:Small perimeter speed
+	line:Small perimeter/radius speed
 		setting:label_width$8:width$4:small_perimeter_speed
 		setting:label_width$8:width$4:small_perimeter_min_length
 		setting:label_width$8:width$4:small_perimeter_max_length

--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -5158,11 +5158,34 @@ std::string GCode::_extrude(const ExtrusionPath &path, const std::string &descri
                     const Slic3r::Geometry::ArcSegment& arc = fitting_result[fitting_index].arc_data;
                     const double arc_length = fitting_result[fitting_index].arc_data.length * SCALING_FACTOR;
                     const Vec2d center_offset = this->point_to_gcode(arc.center) - this->point_to_gcode(arc.start_point);
+
+                    double arc_speed = 0;
+                    if (m_config.small_perimeter_speed.getFloat() > 0 && is_perimeter(path.role()) && path.role() != erThinWall) {
+
+                        double full_arc_len = 2 * PI * arc.radius * SCALING_FACTOR;
+
+                        coordf_t min_length = (this->m_config.small_perimeter_min_length.get_abs_value(EXTRUDER_CONFIG_WITH_DEFAULT(nozzle_diameter, 0)));
+                        coordf_t max_length = (this->m_config.small_perimeter_max_length.get_abs_value(EXTRUDER_CONFIG_WITH_DEFAULT(nozzle_diameter, 0)));
+                        max_length = std::max(min_length, max_length);
+                        double factor = 0;
+
+                        if (full_arc_len < min_length) {
+                            arc_speed = m_config.small_perimeter_speed.get_abs_value(m_config.perimeter_speed);
+                        }
+                        else {
+                            if (full_arc_len < max_length) {
+                                factor = (full_arc_len - min_length) / (max_length - min_length);
+                                arc_speed = m_config.small_perimeter_speed.get_abs_value(m_config.perimeter_speed) + factor * (m_writer.get_speed() - m_config.small_perimeter_speed);
+                            }
+                        }
+                    }
+
                     gcode += m_writer.extrude_arc_to_xy(
                         this->point_to_gcode(arc.end_point),
                         center_offset,
                         e_per_mm * arc_length,
                         arc.direction == Slic3r::Geometry::ArcDirection::Arc_Dir_CCW,
+                        arc_speed,
                         comment);
                     break;
                 }

--- a/src/libslic3r/GCodeWriter.cpp
+++ b/src/libslic3r/GCodeWriter.cpp
@@ -559,7 +559,7 @@ std::string GCodeWriter::extrude_to_xy(const Vec2d &point, double dE, const std:
 //BBS: generate G2 or G3 extrude which moves by arc
 //point is end point which means X and Y axis
 //center_offset is I and J axis
-std::string GCodeWriter::extrude_arc_to_xy(const Vec2d& point, const Vec2d& center_offset, double dE, const bool is_ccw, const std::string& comment)
+std::string GCodeWriter::extrude_arc_to_xy(const Vec2d& point, const Vec2d& center_offset, double dE, const bool is_ccw, double speed, const std::string& comment)
 {
     m_pos.x() = point.x();
     m_pos.y() = point.y();
@@ -568,10 +568,17 @@ std::string GCodeWriter::extrude_arc_to_xy(const Vec2d& point, const Vec2d& cent
     GCodeG2G3Formatter w(this->config.gcode_precision_xyz.value, this->config.gcode_precision_e.value, is_ccw);
     w.emit_xy(point);
     w.emit_ij(center_offset);
+    if (speed > 0)
+        w.emit_f(speed * 60);
     if (is_extrude)
         w.emit_e(m_extrusion_axis, m_tool->E());
     //BBS
     w.emit_comment(this->config.gcode_comments, comment);
+
+    if (speed > 0) {
+        //restore current speed in gcode
+        w.emit_string("\n" + this->set_speed(this->get_speed()));
+    }
     return w.string();
 }
 

--- a/src/libslic3r/GCodeWriter.hpp
+++ b/src/libslic3r/GCodeWriter.hpp
@@ -71,7 +71,7 @@ public:
     std::string travel_to_z(double z, const std::string &comment = std::string());
     bool        will_move_z(double z) const;
     std::string extrude_to_xy(const Vec2d &point, double dE, const std::string &comment = std::string());
-    std::string extrude_arc_to_xy(const Vec2d& point, const Vec2d& center_offset, double dE, const bool is_ccw, const std::string& comment = std::string()); //BBS: generate G2 or G3 extrude which moves by arc
+    std::string extrude_arc_to_xy(const Vec2d& point, const Vec2d& center_offset, double dE, const bool is_ccw, double speed, const std::string& comment = std::string()); //BBS: generate G2 or G3 extrude which moves by arc
     std::string extrude_to_xyz(const Vec3d &point, double dE, const std::string &comment = std::string());
     std::string retract(bool before_wipe = false);
     std::string retract_for_toolchange(bool before_wipe = false);

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4682,9 +4682,10 @@ void PrintConfigDef::init_fff_params()
 
     def = this->add("small_perimeter_speed", coFloatOrPercent);
     def->label = L("Speed");
-    def->full_label = L("Small perimeters speed");
+    def->full_label = L("Small perimeters/radius speed");
     def->category = OptionCategory::speed;
-    def->tooltip = L("This separate setting will affect the speed of perimeters having radius <= 6.5mm (usually holes)."
+    def->tooltip = L("This separate setting will affect the speed of perimeters having small (less then Max length) length (usually holes)."
+                   " If Arc fitting on Printer page is enabled it's also applied to part of long perimeters having radius less then 'Max length/6.28' (2Pi)."
                    "\nIf expressed as percentage (for example: 80%) it will be calculated on the Internal Perimeters speed setting above."
                    "\nSet zero to disable.");
     def->sidetext = L("mm/s or %");


### PR DESCRIPTION
Existing feature "Small perimeter speed" is applied to the hole perimeter length, e.g. small holes, but small details of large perimeter are still printed with full speed:
![image](https://user-images.githubusercontent.com/8691781/227704215-8e5748ff-2c40-4970-acdc-4de25cc15b5c.png)

This PR applies slow down for arcs with small radius when G2/G3 commands are enabled:

![image](https://user-images.githubusercontent.com/8691781/227704468-014a62d7-dbdc-4c8c-9992-f9e0a3c6e45d.png)

Increasing fitting tolerance slow down more, probably by using smaller radius.
