### PR TITLE
Separate preset save and save-as. Resolves #2731.

### DIFF
--- a/resources/icons/save_as.svg
+++ b/resources/icons/save_as.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.0" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	y="0px" viewBox="0 0 16 16" enable-background="new 0 0 16 16" xml:space="preserve">
+	<g id="save">
+		<g>
+			<path fill="#808080" d="M12,2c1.44,0,2,0.56,2,2v10L2,14L2,2H12 M12,1H2C1.45,1,1,1.45,1,2V14c0,0.55,0.45,1,1,1h12
+			c0.55,0,1-0.45,1-1l0-10C15,2,14,1,12,1L12,1z" />
+		</g>
+		<g>
+			<line fill="none" stroke="#808080" stroke-linecap="round" stroke-miterlimit="10" x1="3" y1="8" x2="10"
+				y2="8" />
+		</g>
+		<g>
+			<line fill="none" stroke="#808080" stroke-linecap="round" stroke-miterlimit="10" x1="3" y1="10" x2="10"
+				y2="10" />
+		</g>
+		<g>
+			<line fill="none" stroke="#808080" stroke-linecap="round" stroke-miterlimit="10" x1="3" y1="12" x2="7"
+				y2="12" />
+		</g>
+		<g>
+			<path fill="#2172eb" d="M11,1H5C4.45,1,4,1.45,4,2V5c0,0.55,0.45,1,1,1H11c0.55,0,1-0.45,1-1V2C12,1.45,11.55,1,11,1z M6,4.5
+			C6,4.78,5.78,5,5.5,5S5,4.78,5,4.5v-2C5,2.22,5.22,2,5.5,2S6,2.22,6,2.5V4.5z" />
+		</g>
+		<g>
+			<line fill="none" stroke="#808080" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" x1="3" y1="8" x2="13"
+				y2="8" />
+			<line fill="none" stroke="#808080" stroke-linecap="round" stroke-miterlimit="10" stroke-width="3" x1="8" y1="3" x2="8"
+				y2="13" />
+
+		</g>
+		<g>
+			<line fill="none" stroke="#2172eb" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" x1="3"
+				y1="8" x2="13" y2="8" />
+
+			<line fill="none" stroke="#2172eb" stroke-linecap="round" stroke-miterlimit="10" stroke-width="2" x1="8"
+				y1="3" x2="8" y2="13" />
+
+		</g>
+</svg>

--- a/src/slic3r/GUI/Tab.cpp
+++ b/src/slic3r/GUI/Tab.cpp
@@ -216,6 +216,7 @@ void Tab::create_preset_tab()
 
     add_scaled_button(panel, &m_btn_compare_preset, "compare");
     add_scaled_button(panel, &m_btn_save_preset, "save");
+    add_scaled_button(panel, &m_btn_save_preset_as, "save_as");
     add_scaled_button(panel, &m_btn_delete_preset, "cross");
     if (m_type == Preset::Type::TYPE_PRINTER)
         add_scaled_button(panel, &m_btn_edit_ph_printer, "cog");
@@ -229,6 +230,8 @@ void Tab::create_preset_tab()
     m_btn_compare_preset->SetToolTip(_L("Compare this preset with some another"));
     // TRN "Save current Settings"
     m_btn_save_preset->SetToolTip(from_u8((boost::format(_utf8(L("Save current %s"))) % m_title).str()));
+    m_btn_save_preset_as->SetToolTip(from_u8((boost::format(_utf8(L("Save current %s as new preset"))) % m_title).str()));
+
     m_btn_delete_preset->SetToolTip(_(L("Delete this preset")));
     m_btn_delete_preset->Hide();
 
@@ -280,6 +283,8 @@ void Tab::create_preset_tab()
     m_hsizer->Add(m_presets_choice, 0, wxLEFT | wxRIGHT | wxTOP | wxALIGN_CENTER_VERTICAL, 3);
     m_hsizer->AddSpacer(int(4*scale_factor));
     m_hsizer->Add(m_btn_save_preset, 0, wxALIGN_CENTER_VERTICAL);
+    m_hsizer->AddSpacer(int(4 * scale_factor));
+    m_hsizer->Add(m_btn_save_preset_as, 0, wxALIGN_CENTER_VERTICAL);
     m_hsizer->AddSpacer(int(4 * scale_factor));
     m_hsizer->Add(m_btn_delete_preset, 0, wxALIGN_CENTER_VERTICAL);
     if (m_btn_edit_ph_printer) {
@@ -371,7 +376,10 @@ void Tab::create_preset_tab()
     m_hsizer->Add(m_page_view, 1, wxEXPAND | wxLEFT, 5);
 
     m_btn_compare_preset->Bind(wxEVT_BUTTON, ([this](wxCommandEvent e) { compare_preset(); }));
-    m_btn_save_preset->Bind(wxEVT_BUTTON, ([this](wxCommandEvent e) { save_preset(); }));
+    m_btn_save_preset->Bind(wxEVT_BUTTON, ([this](wxCommandEvent e) {
+                                save_preset(this->get_presets()->get_selected_preset_name());
+                            }));
+    m_btn_save_preset_as->Bind(wxEVT_BUTTON, ([this](wxCommandEvent e) { save_preset(); }));
     m_btn_delete_preset->Bind(wxEVT_BUTTON, ([this](wxCommandEvent e) { delete_preset(); }));
     m_btn_hide_incompatible_presets->Bind(wxEVT_BUTTON, ([this](wxCommandEvent e) {
         toggle_show_hide_incompatible();

--- a/src/slic3r/GUI/Tab.hpp
+++ b/src/slic3r/GUI/Tab.hpp
@@ -172,6 +172,7 @@ protected:
 	ScalableButton*		m_search_btn;
 	ScalableButton*		m_btn_compare_preset;
 	ScalableButton*		m_btn_save_preset;
+	ScalableButton*		m_btn_save_preset_as;
 	ScalableButton*		m_btn_delete_preset;
 	ScalableButton*		m_btn_edit_ph_printer {nullptr};
 	ScalableButton*		m_btn_hide_incompatible_presets;


### PR DESCRIPTION
This takes advantage of the fact that the `save_preset` function accepts a name, which hasn't historically been used by the save button.