### PR TITLE
[pause_print_gcode] choose default value based on g-code flavor

### DIFF
--- a/src/libslic3r/GCode.cpp
+++ b/src/libslic3r/GCode.cpp
@@ -809,7 +809,7 @@ namespace DoExport {
         if (ret.size() < MAX_TAGS_COUNT) check(_(L("Tool change G-code")), config.toolchange_gcode.value);
         if (ret.size() < MAX_TAGS_COUNT) check(_(L("Between objects G-code (for sequential printing)")), config.between_objects_gcode.value);
         if (ret.size() < MAX_TAGS_COUNT) check(_(L("Color Change G-code")), config.color_change_gcode.value);
-        if (ret.size() < MAX_TAGS_COUNT) check(_(L("Pause Print G-code")), config.pause_print_gcode.value);
+        if (ret.size() < MAX_TAGS_COUNT) check(_(L("Pause Print G-code")), print.pause_print_gcode());
         if (ret.size() < MAX_TAGS_COUNT) check(_(L("Template Custom G-code")), config.template_custom_gcode.value);
         if (ret.size() < MAX_TAGS_COUNT) {
             for (const std::string& value : config.start_filament_gcode.values) {
@@ -2532,7 +2532,7 @@ std::string emit_custom_gcode_per_print_z(
                     ) {
                     //! FIXME_in_fw show message during print pause
                     cfg.set_key_value("color_change_extruder", new ConfigOptionInt(m600_extruder_before_layer));
-                    gcode += gcodegen.placeholder_parser_process("pause_print_gcode", print.config().pause_print_gcode, current_extruder_id, &cfg);
+                    gcode += gcodegen.placeholder_parser_process("pause_print_gcode", print.pause_print_gcode(), current_extruder_id, &cfg);
                     gcode += "\n";
                     gcode += "M117 Change filament for Extruder " + std::to_string(m600_extruder_before_layer) + "\n";
                 }
@@ -2555,7 +2555,7 @@ std::string emit_custom_gcode_per_print_z(
                     //! FIXME_in_fw show message during print pause
                     if (!pause_print_msg.empty())
                         gcode += "M117 " + pause_print_msg + "\n";
-                    gcode += gcodegen.placeholder_parser_process("pause_print_gcode", print.config().pause_print_gcode, current_extruder_id);
+                    gcode += gcodegen.placeholder_parser_process("pause_print_gcode", print.pause_print_gcode(), current_extruder_id);
                 } else {
                     // add tag for processor
                     gcode += ";" + GCodeProcessor::reserved_tag(GCodeProcessor::ETags::Custom_Code) + "\n";

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1646,6 +1646,15 @@ void Print::_make_wipe_tower()
     m_wipe_tower_data.number_of_toolchanges = wipe_tower.get_number_of_toolchanges();
 }
 
+std::string Print::pause_print_gcode() const
+{
+    if (m_config.pause_print_gcode.value.empty()) {
+        return std::string(m_config.gcode_flavor == gcfKlipper ? "PAUSE" : "M601")
+    } else {
+        return m_config.pause_print_gcode.value
+    }
+}
+
 // Generate a recommended G-code output file name based on the format template, default extension, and template parameters
 // (timestamps, object placeholders derived from the model, current placeholder prameters and print statistics.
 // Use the final print statistics if available, or just keep the print statistics placeholders if not available yet (before G-code is finalized).

--- a/src/libslic3r/Print.cpp
+++ b/src/libslic3r/Print.cpp
@@ -1649,9 +1649,9 @@ void Print::_make_wipe_tower()
 std::string Print::pause_print_gcode() const
 {
     if (m_config.pause_print_gcode.value.empty()) {
-        return std::string(m_config.gcode_flavor == gcfKlipper ? "PAUSE" : "M601")
+        return std::string(m_config.gcode_flavor == gcfKlipper ? "PAUSE" : "M601");
     } else {
-        return m_config.pause_print_gcode.value
+        return m_config.pause_print_gcode.value;
     }
 }
 

--- a/src/libslic3r/Print.hpp
+++ b/src/libslic3r/Print.hpp
@@ -646,6 +646,7 @@ public:
     const WipeTowerData&        wipe_tower_data() const { return wipe_tower_data(0,0); }
     const ToolOrdering& 		tool_ordering() const { return m_tool_ordering; }
 
+	std::string                 pause_print_gcode() const;
 	std::string                 output_filename(const std::string &filename_base = std::string()) const override;
 
     size_t                      num_print_regions() const throw() { return m_print_regions.size(); }

--- a/src/libslic3r/PrintConfig.cpp
+++ b/src/libslic3r/PrintConfig.cpp
@@ -4670,12 +4670,12 @@ void PrintConfigDef::init_fff_params()
 
     def = this->add("pause_print_gcode", coString);
     def->label = L("Pause Print G-code");
-    def->tooltip = L("This G-code will be used as a code for the pause print");
+    def->tooltip = L("This G-code will be used as a code for the pause print. If empty, the default pause print command for the selected G-code flavor will be used.");
     def->multiline = true;
     def->full_width = true;
     def->height = 12;
     def->mode = comExpert | comPrusa;
-    def->set_default_value(new ConfigOptionString("M601"));
+    def->set_default_value(new ConfigOptionString(""));
 
     def = this->add("template_custom_gcode", coString);
     def->label = L("Custom G-code");

--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -51,10 +51,11 @@ wxDEFINE_EVENT(wxCUSTOMEVT_TICKSCHANGED, wxEvent);
 
 static std::string gcode(Type type)
 {
-    const PrintConfig& config = GUI::wxGetApp().plater()->fff_print().config();
+    const Print& print = GUI::wxGetApp().plater()->fff_print();
+    const PrintConfig& config = print.config();
     switch (type) {
     case ColorChange: return config.color_change_gcode;
-    case PausePrint:  return config.pause_print_gcode;
+    case PausePrint:  return print.pause_print_gcode();
     case Template:    return config.template_custom_gcode;
     default:          return "";
     }

--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -1987,7 +1987,6 @@ void Control::show_add_context_menu()
         append_add_color_change_menu_item(&menu);
     }
 
-    if (!gcode(PausePrint).empty())
     append_menu_item(&menu, wxID_ANY, _L("Add pause print") + " (" + gcode(PausePrint) + ")", "",
         [this](wxCommandEvent&) { add_code_as_tick(PausePrint); }, "pause_print", &menu);
 

--- a/src/slic3r/GUI/DoubleSlider.cpp
+++ b/src/slic3r/GUI/DoubleSlider.cpp
@@ -1988,6 +1988,7 @@ void Control::show_add_context_menu()
         append_add_color_change_menu_item(&menu);
     }
 
+    if (!gcode(PausePrint).empty())
     append_menu_item(&menu, wxID_ANY, _L("Add pause print") + " (" + gcode(PausePrint) + ")", "",
         [this](wxCommandEvent&) { add_code_as_tick(PausePrint); }, "pause_print", &menu);
 


### PR DESCRIPTION
So, I didn't see an obvious mechanism for dynamic default values, it looks like the go-to scheme for dynamic defaults is to have some placeholder value (0, empty string, etc) to represent the default, and then the actual default is computed during gcode generation, so that's what I went with here, an empty string now represents "figure it out for me". I wasn't quite sure where to put the code for computing the final value, I think the `Print` class is appropriate? There were multiple references to the final value so I didn't wanna just do it inline in `GCode.cpp`.

To me this looks like a trivial change but I'm not a C++ developer so let me know if there's problems I'm not aware of.