### PR TITLE
Missformatted URL if no additional GET Parameter has been supplied

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -3118,7 +3118,15 @@ wxString GUI_App::current_language_code_safe() const
 
 void GUI_App::open_web_page_localized(const std::string &http_address)
 {
-    open_browser_with_warning_dialog(http_address + "&lng=" + this->current_language_code_safe(), nullptr, false);
+    std::string lng_param = "lng=" + this->current_language_code_safe();
+
+    // Check if http_address already contains a query parameter
+    size_t query_pos = http_address.find('?');
+    if (query_pos == std::string::npos) {
+        open_browser_with_warning_dialog(http_address + "?" + lng_param, nullptr, false);
+        return;
+    } 
+    open_browser_with_warning_dialog(http_address + "&" + lng_param, nullptr, false);
 }
 
 // If we are switching from the FFF-preset to the SLA, we should to control the printed objects if they have a part(s).


### PR DESCRIPTION
https://github.com/supermerill/SuperSlicer/blob/69c3980007b408220dfabc8c819645c8852cdd4e/src/slic3r/GUI/GUI_App.cpp#L3121

There is an issue with the URL fromat. If no parameter is supplied, the URL will attach the &, which will cause an invalid URL.
If there is no previous parameter set, we need to use instead of the &.