### PR TITLE
[doc] calibration html files translated to es_ES

### DIFF
--- a/resources/calibration/bed_leveling/es_bed_leveling.html
+++ b/resources/calibration/bed_leveling/es_bed_leveling.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Nivelaci&oacute;n de la cama</title>
+</head>
+<body>
+<table width="100%">
+<tbody>
+<tr>
+<td style="text-align: center;">
+<h1 style="text-align: center;">Nivelaci&oacute;n de la cama</h1>
+</td>
+</tr>
+<tr>
+    <td style="text-align: right;">
+        <table><tr><td>Necesita:</td>
+            <td style="text-align: left;">Nada</td></tr>
+        </table>
+</tr>
+</tbody>
+</table>
+<p>Esta calibraci&oacute;n es la primera a realizar porque se necesita una buena adhesi&oacute;n del filamento a la cama caliente.</p>
+<p>Esta calibraci&oacute;n se realiza para obtener un ajuste fino. Por favor realice una nivelaci&oacute;n de la cama antes de empezar y mueva la boquilla a 0.2mm por encima de la cama. Debe ser capaz de mover un folio de papel entre la boquilla y la cama, pero debe sentir como la boquilla roza el folio. Despu&eacute;s de eso, deber&iacute;a ser capaz de nivelar la cama con una precisi&oacute;n de ~0.1mm aproximadamente.</p>
+<h2>C&oacute;mo funciona</h2>
+<p>Primero, seleccione su impresora y su perfil de impresi&oacute;n por defecto con el perfil de filamento adecuado para dicho filamento (PLA, ABS). Tenga en cuenta que esta calibraci&oacute;n solo funciona para el primer extrusor si dispone de varios.</p>
+<p>Cuando presione el bot&oacute;n Generate, el programa crear&aacute; y laminar&aacute; el test de impresi&oacute;n. Tienes que enviarlo a la impresora e imprimirlo. Finalizada la impresi&oacute;n compare las 5 peque&ntilde;as piezas impresas con las fotos de abajo. Tendr&aacute; que afinar su impresora / firmware para corregir la altura si es necesario.</p>
+<p>Lea las notas y consejos m&aacute;s abajo para m&aacute;s informaci&oacute;n.</p>
+<h2>Resultados</h2>
+<table width="100%">
+<tbody>
+<tr>
+<td><img src="./low_ll.jpg" width="100" height="200" /></td>
+<td><img src="./low_l.jpg" width="100" height="200" /></td>
+<td><img src="./low.jpg" width="100" height="200" /></td>
+<td><img src="./good.jpg" width="100" height="200" /></td>
+<td><img src="./high.jpg" width="100" height="200" /></td>
+<td><img src="./high_h.jpg" width="100" height="200" /></td>
+<td><img src="./high_hh.jpg" width="100" height="200" /></td>
+</tr>
+<tr>
+<td style="text-align: center;">Demasiado lejos</td>
+<td style="text-align: center;">Muy lejos</td>
+<td style="text-align: center;">A&uacute;n lejos:<br />puede ver un<br />peque&ntilde;o hueco</td>
+<td style="text-align: center;">Perfecto</td>
+<td style="text-align: center;">todav&iacute;a cerca</td>
+<td style="text-align: center;">&iexcl;Atenci&oacute;n!<br />Muy cerca:<br />comprueba el grosor<br />&iexcl;con sus dedos!</td>
+<td style="text-align: center;">Demasiado cerca<br />Peligro para<br />la cama</td>
+</tr>
+</table>
+<h2>C&oacute;mo afinar la impresora</h2>
+<p><strong>Si tu impresora tiene tornillos de nivelaci&oacute;n  de cama</strong>, &uacute;salos para subir o bajar la cama donde la pieza en cuesti&oacute;n haya quedado muy lejos o muy cerca de la cama. No olvide repetir la impresi&oacute;n despu&eacute;s de efectuar los ajustes de la cama para verificar la compensaci&oacute;n realizada. Tenga cuidado, la mayor&iacute;a de las veces, media vuelta de giro a esos tornillos, corresponden con 0.2mm de altura, que t&iacute;picamente es la altura de la primera capa. Si eleva la cama, nunca gire m&aacute;s de media vuelta, normalmente deber&iacute;a girar un cuarto de vuelta el tornillo e imprimir de nuevo.</p>
+<p><strong>Si no dispone de tornillos de ajuste de la cama</strong>, tiene que usar el programa suministrado por el fabricante o el firmware. Revise el manual de su impresora.</p>
+<h2>Consejos</h2>
+<p>Si el filamento no se adhiere a la cama caliente puede intentar: </p>
+<ul>
+<li>Aumentar el ancho de extrusi&oacute;n, aumentar&aacute; la presi&oacute;n sin sobre-extruir. Puede aumentarlo hasta el 200% del di&aacute;metro de su boquilla, pero 150% deber&iacute;a ser suficiente. (Opciones Avanzadas, Configuraci&oacute;n de Impresi&oacute;n -> Width (ancho)</li>
+<li>Reducir la velocidad de impresi&oacute;n para dar tiempo a que se adhiera a la cama. (Opciones avanzadas, Configuraci&oacute;n de Impresi&oacute;n -> Velocidad)</li>
+<li>Puede des/habilitar "z-hop" para la primera capa "Solo Levantar Z"-&gt; "Encima de Z" para un valor mayor a la altura de su primera capa. Si lo activa, puede levantar el filamento de la cama y si lo desactiva, puede que la boquilla roce en la cama y empuje el filamento depositado, as&iacute; que debe hacer pruebas para encontrar el valor &oacute;ptimo. (Opciones Avanzadas, Configuraci&oacute;n de la Impresora -> Extrusor)</li>
+</ul>
+<h2>Notas</h2>
+<p>Este test usa su configuraci&oacute;n actual de altura de primera capa, pero quiz&aacute;s desee incrementar el valor hasta el 80 % del di&aacute;metro de su boquilla (antes de usar el boton 'generate'), sobre todo si es la primera vez que realiza este test y desea evitar el riesgo de que la boquilla colisione con la cama. Para una boquilla de 0.4 mm de di&aacute;metro, el m&aacute;ximo alto de capa sugerido ser&iacute;a 0.4 * 80% = 0.32 mm, dejando m&aacute;s espacio entre cama y boquilla para evitar colisiones.</p>
+<p>Si despu&eacute;s de la calibraci&oacute;n del flujo de filamento parece que el valor del flujo es totalmente err&oacute;neo, puede realizar este test una vez m&aacute;s deshaciendo este cambio sugerido en el p&aacute;rrafo anterior.</p>
+<p>La mayor&iacute;a de las calibraciones deben ser realizadas en el orden correcto. &Eacute;ste es el primero a realizar. Si desea obtener buenos resultados necesita calibrar su extrusor, por ejemplo: Si solicita extruir 100mm de filamento, esa es la cantidad justa de filamento que debe consumir a la entrada del extrusor.</p>
+<p>Este test establece la opci&oacute;n "Completar objetos individuales", quiz&aacute;s desee resetear la Configuraci&oacute;n de Impresi&oacute;n despu&eacute;s de imprimir el test.</p>
+<p>Licencia de los modelos usados en este test de calibraci&oacute;n: CC BY-SA 3.0</p>
+</body>
+</html>

--- a/resources/calibration/bridge_flow/es_bridge_flow.html
+++ b/resources/calibration/bridge_flow/es_bridge_flow.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Calibraci&oacute;n del ratio de Flujo en Puentes</title>
+</head>
+<body>
+
+<table width="100%">
+<tbody>
+<tr>
+<td style="text-align: center;">
+<h1>Calibraci&oacute;n del ratio de Flujo en Puentes</h1>
+</td>
+</tr>
+<tr>
+<td style="text-align: right;"><strong>
+    <table><tr><td>Necesita:</td>
+        <td style="text-align: left;">Flujo</td>
+        <td style="text-align: left;">Temperatura</td></tr>
+    </table>
+    </strong>
+</tr>
+</tbody>
+</table>
+
+<p><strong>Necesita realizar la calibraci&oacute;n de la cama y la calibraci&oacute;n de Flujo de Filamento antes de este test.</strong> Mejor a&uacute;n si ha realizado la calibraci&oacute;n de temperatura del filamento previamente.</p>
+<p>Este test imprimir&aacute; varios ejemplos de puentes modificando el ratio de flujo en puentes. Usa su configuraci&oacute;n actual, as&iacute; que quiz&aacute;s desee establecerlo en 100% antes de pulsar el bot&oacute;n.</p>
+<!-- <h2>Results</h2> -->
+<!-- <table> -->
+<!-- <tbody> -->
+<!-- <h4>Exemple:</h4> -->
+<!-- <tr> -->
+<!-- <td>TODO</td> -->
+<!-- </tr> -->
+<!-- <tr> -->
+<!-- <td style="text-align: center;">TODO</td> -->
+<!-- </tr> -->
+<!-- </table> -->
+
+<!-- <h2>Advice</h2> -->
+<!-- <p>TODO</p> -->
+<!-- </ul> -->
+<h2>Notes</h2>
+<p>Este test establece la opci&oacute;n "Completar objetos individuales", quiz&aacute;s desee resetear la Configuraci&oacute;n de Impresi&oacute;n despu&eacute;s de imprimir el test, o deshabilitar esta opci&oacute;n si su cama es muy peque&ntilde;a.</p>
+<p>Licencia de los modelos usados en este test de calibraci&oacute;n: CC BY-SA 3.0</p>
+</body>
+</html>

--- a/resources/calibration/cube/es_cube.html
+++ b/resources/calibration/cube/es_cube.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cubo de Calibraci&oacute;n</title>
+</head>
+<body>
+
+<table width="100%">
+<tbody>
+<tr>
+<td style="text-align: center;">
+<h1>Cubo de Calibraci&oacute;n</h1>
+</td>
+</tr>
+<tr>
+<td style="text-align: right;"><strong>
+    <table><tr><td>Necesita:</td>
+        <td style="text-align: left;">Calibraci&oacute;n cama</td>
+        <td style="text-align: left;">Flujo</td>
+        <td style="text-align: left;">Temperatura</td></tr>
+    </table>
+    </strong>
+</tr>
+</tbody>
+</table>
+
+<p>Esta p&aacute;gina le permite imprimir el amado cubo de calibraci&oacute;n. Es &uacute;til ver si su impresora es exacta y calibrar algunos ajustes. Lo primero es establecer sus objetivos.</p>
+<h2>Objetivo: exactitud dimensional</h2>
+<p>Tiene que imprimir dos cubos, de diferente tama&ntilde;o. Si sus dimensiones impresas han escalado proporcionalmente del tama&ntilde;o de los cubos originales, entonces necesita ajustar los pasos/mm de sus motores (nota: si es el caso, tambi&eacute;n debe ajustar el flujo, y puede que deba rehacer otras calibraciones si el cambio es grande). Si las dimensiones no han escalado proporcionalmente, puede corregir el desfase ajustando la compensaci&oacute;n en XY (Ajustes Avanzados, Configuraci&oacute;n de Impresi&oacute;n, Laminando -> XY First Layer Compensation). Con el bot&oacute;n Voron cube, puede testear la calibraci&oacute;n de agujeros, ya que normalmente son m&aacute;s peque&ntilde;os de lo que deber&iacute;an. El agujero de arriba deber&iacute;a ser suficientemente grande (en la versi&oacute;n de 30mm) para encajar un rodamiento en &eacute;l.</p>
+<h2>Objetivo: Superposici&oacute;n relleno/per&iacute;metros</h2>
+<p>Este test sirve para ver si el relleno atraviesa el per&iacute;metro. Intente reducirlo al m&iacute;nimo posible pero debe comprobar la capa s&oacute;lida superior, ya que puede crear artefactos si es demasiado bajo. Es mejor imprimir el cubo estandard, ya que tiene una superficie superior mayor para apreciar el posible problema.</p>
+<!-- <h2>Objetivo: Superposici&oacute;n del per&iacute;metro externo</h2> -->
+<!-- <p>Como el per&iacute;metro externo es impreso lo &uacute;ltimo, la posici&oacute;n real depende de la posici&oacute;n de toda la capa y el flujo. As&iacute; que debe estar seguro que su flujo es perfecto antes de hacer este test.La diferencia principal entre capas con relleno s&oacute;lido o capas con relleno parcial, es que las capas s&oacute;lidas pueden empujar el per&iacute;metro externo hacia afuera de la pieza. Decrementando la superposici&oacute;n relleno/per&iacute;metro, decrementando la superposici&oacute;n del per&iacute;metro externo puede ayudar a reducir este efecto.</p> -->
+<h2>Notas</h2>
+<p>Este test debe ser el &uacute;ltimo test a realizar.</p>
+<p>El tama&ntilde;o del cubo standard es de 20mm y el tama&ntilde;o del cubo Voron es de 30mm.</p>
+<p>Licencia del cubo standard de calibraci&oacute;n: CC BY-SA 3.0, <a href="https://www.thingiverse.com/thing:1278865">realizado por iDig3Dprinting</a></p>
+<p>Licencia del cubo Voron de calibraci&oacute;n: GPL V3, <a href="https://github.com/VoronDesign/Voron-2">realizado por VORONDesign</a></p>
+</body>
+</html>

--- a/resources/calibration/es_introduction.html
+++ b/resources/calibration/es_introduction.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <title>Calibraciones</title>
+</head>
+<body>
+<h1 style="text-align: center;">Introducci&oacute;n</h1>
+<p>Bienvenido al men&uacute; de calibraci&oacute;n. &Eacute;ste men&uacute; le ayudar&aacute; a imprimir calibraciones r&aacute;pida y eficientemente</p>
+<h2>&iquest;Por qu&eacute;?</h2>
+<p>La mayor&iacute;a de impresoras deber&iacute;an imprimir bastante bien con la configuraci&oacute;n de f&aacute;brica, pero si encuentra algun problema, o si desea ir un paso m&aacute;s all&aacute; en calidad, tendr&iacute;a que asegurarse que todo est&aacute; bien calibrado. Las calibraciones se pueden dividir en tres grupos: impresora, filamento y laminador.</p>
+<p>La impresora debe calibrarse primero, despu&eacute;s el filamento y por &uacute;ltimo el laminador.</p>
+<h2>Calibraci&oacute;n de impresora</h2>
+<p>&Eacute;sto es lo primero a calibrar. Cada impresora es diferente en este aspecto, y deber&iacute;a leer el manual de su impresora para m&aacute;s informaci&oacute;n.</p>
+<h3>Calibraci&oacute;n del extrusor</h3>
+<p>No tiene una entrada de men&uacute;, porque no puede calibrarse con una impresi&oacute;n. No es obligatorio pero puede ayudar a evitar algunos problemas. La mayor&iacute;a est&aacute; explicado en el men&uacute; calibraci&oacute;n de flujo.</p>
+<h3>Nivelaci&oacute;n de cama</h3>
+<p>La mayor&iacute;a de impresoras no tienen sistema de nivelaci&oacute;n de cama, e incluso aquellas que lo tienen, deben ser calibrados al menos una vez. Estos men&uacute;es explicar&aacute;n muchas cosas, pero aseg&uacute;rese de leer la documentaci&oacute;n de su impresora en el caso de existir pasos espec&iacute;ficos para su impresora en concreto. &Eacute;sta calibraci&oacute;n es particularmente &uacute;til si desea verificar / afinar el resultado final, o si desea comprobar que no ha cambiado desde la &uacute;ltima vez.</p>
+<p>Crear&aacute; 5 peque&ntilde;as piezas. Visualmente deber&iacute;a comprobar las piezas y ver&aacute; donde la cama est&aacute; nivelada y donde necesita realizar algunos ajustes.</p>
+<h2>Calibraci&oacute;n de filamento</h2>
+<p> Cada filamento tiene propiedades diferentes y puede necesitar ajustes. Aunque el perfil por defecto deber&iacute;a funcionar la mayor&iacute;a de las veces, puede crear defectos evitables. Algunos filamentos especiales (como aquellos que incluyen part&iacute;culas de madera) necesitar&aacute;n ajustes especiales.</p>
+<h3>Calibraci&oacute;n del flujo de filamento</h3>
+<p>El extrusor muerde el filamento para empujarlo, y la fuerza con que los muelles comprimen el filamento, pueden cambiar el flujo necesitado. Adem&aacute;s, si su extrusor no est&aacute; bien calibrado, estos pasos le ayudar&aacute;n a contrarrestar este problema.</p>
+<p>Tenga en cuenta que si su filamento tiene un di&aacute;metro variable o no es totalmente redondo, encontrar&aacute; problemas de flujo, pero &eacute;stas situaciones no pueden arreglarse. Debe cambiar de proveedor / calidad del filamento o invertir en un sensor de grosor de filamento.</p>
+<h3>Calibraci&oacute;n de temperatura del filamento</h3>
+<p>Algunos filamentos necesitan m&aacute;s temperatura para pegarse, otros sin embargo, necesitan menos temperatura para evitar goteos o ca&iacute;das de voladizos (salientes). Esta calibraci&oacute;n le ayudar&aacute; a encontrar un buen valor para la temperatura. Puede realizar varias pruebas modificando la velocidad del ventilador de capa hasta encontrar la mejor combinaci&oacute;n.</p>
+<h2>Calibraci&oacute;n del laminador</h2>
+<p>Estas calibraciones le ayudar&aacute;n a encontrar la mejor configuraci&oacute;n de SuperSlicer para su impresora y filamento.</p>
+<h3>Calibraci&oacute;n de flujo en puentes</h3>
+<p>Los puentes son normalmente dif&iacute;ciles de imprimir con un buen resultado visual. Esta calibraci&oacute;n le ayudar&aacute; a elegir la mejor configuraci&oacute;n para el flujo de filamento en el puente. Tambi&eacute;n puede intentar diferentes velocidades del ventilador de capa para un mismo flujo de filamento en puentes.</p>
+<h3>Calibraci&oacute;n del patr&oacute;n de Alisado</h3>
+<p>Es dif&iacute;cil imprimir una superficie plana y lisa, ya que puede disminuir su altura en el centro de una gran superficie plana. Esta calibraci&oacute;n le ayudar&aacute; a encontrar la mejor configuraci&oacute;n para compensar ese desnivel.</p>
+<h3>Cubo de calibraci&oacute;n</h3>
+<p>Esta entrada le permite tener siempre a mano un cubo de calibraci&oacute;n listo para imprimir. Es muy &uacute;til ver si la impresi&oacute;n tiene una buena exactitud dimensional. Esto puede alterarse con varias opciones de compensaci&oacute;n en X-Y.</p>
+</body>
+</html>

--- a/resources/calibration/filament_flow/es_filament_flow.html
+++ b/resources/calibration/filament_flow/es_filament_flow.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Calibraci&oacute;n del Flujo de Filamento</title>
+</head>
+<body>
+
+<table width="100%">
+<tbody>
+<tr>
+<td style="text-align: center;">
+<h1>Calibraci&oacute;n del Flujo de Filamento</h1>
+</td>
+</tr>
+<tr>
+<td style="text-align: right;"><strong>
+    <table><tr><td>Necesita:</td>
+        <td style="text-align: left;">Nivelaci&oacute;n de cama</td></tr>
+    </table>
+    </strong>
+</tr>
+</tbody>
+</table>
+
+<p><strong>Necesita realizar la Nivelaci&oacute;n de la cama antes de este test.</strong></p>
+<p>Este test imprimir&aacute; cinco piezas con diferentes niveles de flujo. Puede elegir la diferencia de flujo entre cada pieza. Deber&iacute;a empezar con el 10%.
+Despu&eacute;s de verificar el resultado con la ayuda de la tabla siguiente, debe modificar el multiplicador de extrusi&oacute;n del filamento en su perfil de filamento (si el -20 es el mejor, cambie el multiplicador de 1 a 0.8, vea la f&oacute;rmula m&aacute;s abajo). &iexcl;No olvide guardar los cambios en el perfil de filamento! Puede continuar con el bot&oacute;n de 2% si quiere una mayor precisi&oacute;n.</p>
+<h2>Resultados</h2>
+<h4>Ejemplo:</h4>
+<table width="100%">
+<tbody>
+<tr>
+<td><img src="./m20.jpg" width="150" height="150" /></td>
+<td><img src="./m10.jpg" width="150" height="150" /></td>
+<td><img src="./0_v1.jpg" width="150" height="150" /></td>
+<td><img src="./p10.jpg" width="150" height="150" /></td>
+<td><img src="./p20.jpg" width="150" height="150" /></td>
+</tr>
+<tr>
+<td style="text-align: center;">No plano</td>
+<td style="text-align: center;">No plano</td>
+<td style="text-align: center;">No plano</td>
+<td style="text-align: center;">Plano<br />pero el c&iacute;rculo<br />no es tan bueno</td>
+<td style="text-align: center;">Plano<br />y c&iacute;rculo bueno</td>
+</tr>
+</table>
+<p>El flujo que desea elegir es el menor posible que no cree agujeros en la superficie superior. En este ejemplo parece que el mejor flujo es +20. As&iacute; que debe cambiar el multiplicador de extrusion a 1.2 e imprimir el segudo set de pruebas (o puede establecerlo en 1.15 y no contin&uacute;es el test).</p>
+<p>No mire la calidad de las letras, deber&iacute;a ser buena solo en 0, por eso calibramos la altura de la cama para este test de flujo. Aqu&iacute;, usando el flujo +20, deber&iacute;a bajar la cama un poquito (rehaciendo la
+calibraci&oacute;n de la cama).</p>
+<h4>Segundo paso, empezando en +20%:</h4>
+<table>
+<tbody>
+<tr>
+<td><img src="./m8.jpg" width="150" height="150" /></td>
+<td><img src="./m6.jpg" width="150" height="150" /></td>
+<td><img src="./m4.jpg" width="150" height="150" /></td>
+<td><img src="./m2.jpg" width="150" height="150" /></td>
+<td><img src="./0_v2.jpg" width="150" height="150" /></td>
+</tr>
+<tr>
+<td style="text-align: center;">No bueno</td>
+<td style="text-align: center;">No bueno</td>
+<td style="text-align: center;">Casi bueno</td>
+<td style="text-align: center;">Bueno pero el<br />c&iacute;rculo tiene<br />irregularidades</td>
+<td style="text-align: center;">Bueno</td>
+</tr>
+</table>
+<p>Aqu&iacute; podemos ver que el c&iacute;rculo no es muy bueno en el -8 y -6. El -4 es casi redondo pero no perfecto, eso indica que la boquilla perdi&oacute; presi&oacute;n. -2 es casi bueno pero el 0 es el &uacute;nico que puede ser considerado como "bueno", incluso si el c&iacute;rculo no es perfecto.</p>
+<h2>C&oacute;mo afinar la impresora</h2>
+<p>Tiene que cambiar el multiplicador de extrusi&oacute;n para el filamento que ha calibrado (y guardar el perfil). La f&oacute;rmula para el multiplicador de extrusi&oacute;n es: nuevo_multiplicador = ( (100 + numero_elegido) / 100 ) * viejo_multiplicador<br />
+Ejemplo: primer paso, elijo -10, as&iacute; tengo ((100-10)/100) * 1 = (0.9) * 1 = 0.9<br />
+segundo paso elijo +5, as&iacute; tengo ((100+5)/100) * 0.9 = (1.05) * 0.9 = 0.945
+</p>
+<p>Si desea hacer este cambio permanente y mantener su multiplicador de extrusi&oacute;n a 1 en SuperSlicer, puede cambiar la configuraci&oacute;n de su firmware multiplicando (o dividiendo, depende del firmware/configuraci&oacute;n) el 'extruder speed setting' (e-step, step_distance) por su multiplicador de extrusi&oacute;n.</p>
+<h2>Consejos</h2>
+<p>Antes de realizar este test, es preferible calibrar su extrusor (es m&aacute;s f&aacute;cil en sistemas bowden):</p>
+<ul>
+<li>Quite el tubo bowden del extrusor desde la salida del extrusor (o separe el extrusor del fusor si tiene un extrusor en directa)</li>
+<li>Introduzca el filamento a trav&eacute;s del extrusor (a mano o usando el programa que lo controla)</li>
+<li>Corte el filamento a ras de la salida del extrusor. Mide con una regla de acero que efectivamente hay 0mm. Si no lo hay, anote el valor y no olvide restar este valor de todas las dem&aacute;s medidas que realice.</li>
+<li>Ordene extruir 200mm de filamento (gcode: G1 E200).</li>
+<li>Mida la longitud extruida de filamento. Repita el proceso dos veces si desea mayor precisi&oacute;n.</li>
+<li>Tiene que cambiar su multiplicador de extrusi&oacute;n (e-step, step_distance) multiplicando (o dividiendo, dependiendo de su firmware) el valor actual por (200 / media_de_valores_medidos).</li>
+<p>Tenga en cuenta que este valor puede cambiar si cambia la presi&oacute;n ejercida por el extrusor al filamento.</p>
+</ul>
+<h2>Notas</h2>
+<p>Es muy dif&iacute;cil afinar el flujo por debajo del 2%, y de todas formas, no hay filamento tan suficientemente consistente para garantizarlo. Filamentos con precisi&oacute;n de +-0.03mm tiene una variaci&oacute;n del ~7% entre el m&iacute;nimo y m&aacute;ximo de su secci&oacute;n.</p>
+<p>La mayor&iacute;a de las calibraciones deben ser realizadas en el orden correcto. &Eacute;sta deber&iacute;a ser la segunda.</p>
+<p>Quiz&aacute;s desee realizar de nuevo la calibraci&oacute;n de la cama si el resultado es inferior a 0.9 o es m&aacute;s alto de 1.1.</p>
+<p>Tenga en cuenta que el multiplicador de extrusi&oacute;n puede variar con un filamento de diferente material, uno m&aacute;s blando puede ser marcado/mordido con m&aacute;s fuerza por el extrusor y debido a ello tendr&aacute; un menor di&aacute;metro en las ruedas dentadas del extrusor.</p>
+<p>Si el extrusor "se come" el filamento y no puede completar la capa superior, deber&aacute; incrementar la distribuci&oacute;n del Alisado, planchado, Ironing (en incrementos de 5%).(Modo Experto, Configuraci&oacute;n de Impresi&oacute;n -> Relleno)</p>
+<p>Este test establece la opci&oacute;n "Completar objetos individuales", quiz&aacute;s desee resetear la Configuraci&oacute;n de Impresi&oacute;n despu&eacute;s de imprimir el test.</p>
+<p>Licencia de los modelos usados en este test de calibraci&oacute;n: CC BY-SA 3.0</p>
+</body>
+</html>

--- a/resources/calibration/filament_temp/es_filament_temp.html
+++ b/resources/calibration/filament_temp/es_filament_temp.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Calibraci&oacute;n de la Temperatura del Filamento</title>
+</head>
+<body>
+
+<table width="100%">
+<tbody>
+<tr>
+<td style="text-align: center;">
+<h1>Calibraci&oacute;n de la Temperatura del Filamento</h1>
+</td>
+</tr>
+<tr>
+<td style="text-align: right;"><strong>
+	<table><tr><td>Necesita:</td>
+        <td style="text-align: left;">Nivelaci&oacute;n cama</td>
+        <td style="text-align: left;">Flujo</td></tr>
+	</table>
+	</strong>
+</tr>
+</tbody>
+</table>
+
+<p><strong>Necesita haber realizado la calibraci&oacute;n de la cama antes que este test,</strong> y preferiblemente tambi&eacute;n la calibraci&oacute;n del Flujo..
+Esta calibraci&oacute;n le ayudar&aacute; a elegir la correcta temperatura correcta respecto a uni&oacute;n del filamento, voladizos y goteo del fusor.
+Tenga presente que este test depende de la ventilaci&oacute;n de capa elegida. Puede realizar este test varias veces con m&aacute;s o menos porcentaje de ventilaci&oacute;n de capa hasta encontrar el punto exacto.</p>
+<p>Este test imprimir&aacute; una torre, impresa a diferentes temperaturas para cada planta. La planta en la mitad de altura ser&aacute; impresa con la temperatura actual elegida en la configuraci&oacute;n de su filamento. La planta en la base, tocando la cama caliente, ser&aacute; impresa con la m&aacute;xima temperatura y la planta superior con la menor temperatura posible. Puede elegir la diferencia de temperatura entre plantas y el n&uacute;mero de plantas (cuantos test por debajo de la actual temperatura desea y cuantos test con temperaturas superiores) pero puede dejarlo tal cual est&aacute; para empezar.</p>
+<h2>Resultados / observaciones</h2>
+<p>El Objetivo es elegir la temperatura m&aacute;s alta posible que no genere artifactos.</p>
+<p>Primero, debe analizar la torre. Cada planta tiene la temperatura grabada en ella.</p>
+<table width="100%">
+<tbody>
+<tr>
+<td><img src="./temp_tower_180.jpg" width="400" height="100" /></td>
+<td>Demasiado fr&iacute;o, No puede ser extruido</td>
+<td>
+</tr>
+<tr>
+<td><img src="./temp_tower_195.jpg" width="400" height="100" /></td>
+<td>Bien</td>
+</tr>
+<tr>
+<td><img src="./temp_tower_210.jpg" width="400" height="100" /></td>
+<td>Bien</td>
+</tr>
+<tr>
+<td><img src="./temp_tower_225.jpg" width="400" height="100" /></td>
+<td>Demasiado caliente, se ve que la boquilla gotea</td>
+</tr>
+<tr>
+<td><img src="./temp_tower_240.jpg" width="400" height="100" /></td>
+<td>Muy caliente, se ve que la boquilla gotea</td>
+</tr>
+</tbody>
+</table>
+<p>Aqu&iacute; puede ver que la planta impresa a 210 grados celsius es la m&aacute;s caliente que podemos imprimir sin problemas de desintegraci&oacute;n (aparte del calor; la baja calidad de impresi&oacute;n es debido a altas velocidades). Tambi&eacute;n, tuve &eacute;xito al romper (con cierta dificultad) la planta a 195 grados debido a una mala adhesi&oacute;n entre capas; as&iacute; que fue impresa a una baja temperatura para este filamento. Aconsejo hacer el mismo test.</p>
+<h2>Resultados: destrucci&oacute;n</h2>
+<p>Finalmente, Debe romper cada planta por la mitad, para comprobar si las bajas temperaturas de impresi&oacute;n tienen efectos adversos en la uni&oacute;n de las capas. No deber&iacute;a ser posible romper solo con sus manos una planta. Si puede romper una planta, entonces la temperatura de esa planta es definitivamente demasiado baja (o el ventilador de capa ha enfriado demasiado r&aacute;pido esa planta debido al alto caudal de aire), por tanto debe elegir la temperatura m&aacute;s alta posible o repetir el test con menos ventilaci&oacute;n de capa. Cuando intente romper una planta con la mano, no ponga los dedos en la uni&oacute;n de esa planta con la anterior o la siguiente, al cambiar la temperatura en esa zona, es la m&aacute;s d&eacute;bil, sujete el inicio de esa planta y el final de esa misma planta firmemente.</p>
+<h2>C&oacute;mo afinar su impresora</h2>
+<p>Cambie la temperatura en el perfil de filamento (extrusor -> otras capas), despu&eacute;s guarde el perfil. La temperatura de la primera capa casi siempre es 5 grados m&aacute;s para ayudar en la adhesi&oacute;n a la cama, por tanto deber&iacute;a cambiarla tambi&eacute;n, especialmente si es menor a la nueva temperatura.</p>
+</ul>
+<h2>Notas</h2>
+<p>La mayor&iacute;a de las calibraciones debe ser hechas en el orden <strong>correcto</strong>. &Eacute;sta debe ser la tercera.</p>
+<p>Los n&uacute;meros de las temperaturas solo se ver&aacute;n entre 180 y 285. Valores m&aacute;s altos o bajos no se mostraran pero el test se har&aacute; correctamente, solo tiene que recordarlas.</p>
+<p>Esta torre se realiz&oacute; con el modelo 3D <a href="https://www.thingiverse.com/thing:2729076">creado por gaaZolee</a> con la licencia: CC BY-SA 3.0.<p>
+</body>
+</html>

--- a/resources/calibration/over-bridge_tuning/es_over-bridge_tuning.html
+++ b/resources/calibration/over-bridge_tuning/es_over-bridge_tuning.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Calibraci&oacute;n del Patr&oacute;n de Alisado</title>
+</head>
+<body>
+
+<table width="100%">
+<tbody>
+<tr>
+<td style="text-align: center;">
+<h1>Calibraci&oacute;n del Patr&oacute;n de Alisado</h1>
+</td>
+</tr>
+<tr>
+<td style="text-align: right;"><strong>
+    <table><tr><td>Necesita:</td>
+        <td style="text-align: left;">Flujo</td>
+        <td style="text-align: left;">Temperatura</td></tr>
+    </table>
+    </strong>
+</tr>
+</tbody>
+</table>
+
+<p><strong>Necesita realizar la calibraci&oacute;n de flujo del filamento y el ratio de flujo en puentes antes que este test.</strong> Mejor a&uacute;n si ha realizado la calibraci&oacute;n de Temperatura del Filamento.</p>
+<p>&Eacute;ste m&eacute;todo de calibraci&oacute;n imprimir&aacute; varias piezas modificando el ratio de flujo sobre puentes, entre 100 y 125. Elija el menor valor en el que la superficie superior es plana sin "agujeros". Empiece con el bot&oacute;n over-bridge calibration.</p>
+<p>Si la calibraci&oacute;n sobre puentes (Ajustes avanzados, Configuraci&oacute;n de Impresi&oacute;n, Width & Flow, Flow ratio -> Above the bridges) no es concluyente (mismos agujeros en todas las piezas), entonces puede establecer el flujo sobre puentes en 110% y use la opci&oacute;n top fill (Ajustes avanzados, Configuraci&oacute;n de Impresi&oacute;n, Width & Flow, Flow ratio -> Top fill). Este ajuste es un poco impredecible, as&iacute; que lo mejor es no establecerlo lejos del 100%.</p>
+<h2>Resultados</h2>
+<table width="100%">
+<tbody>
+<h4>Ejemplo:</h4>
+<tr>
+<td><img src="./100.jpg" width="150" height="100" /></td>
+<td><img src="./105.jpg" width="150" height="100" /></td>
+<td><img src="./110.jpg" width="150" height="100" /></td>
+<td><img src="./115.jpg" width="150" height="100" /></td>
+<td><img src="./120.jpg" width="150" height="100" /></td>
+</tr>
+<tr>
+<td style="text-align: center;">No plano</td>
+<td style="text-align: center;">No plano</td>
+<td style="text-align: center;">No plano</td>
+<td style="text-align: center;">Plano</td>
+<td style="text-align: center;">Plano</td>
+</tr>
+</table>
+Aqu&iacute;, podemos ver atifactos hasta que el flujo sobre puentes fue establecido a 115. Si era plano en la calibraci&oacute;n del flujo, y ahora no lo es, es porque los puentes debajo de la capas superiores se est&aacute;n cayendo un poco por gravedad, por eso deja m&aacute;s volumen para rellenar. Aqu&iacute; 115 deber&iacute;a ser suficiente, pero 120 es un valor m&aacute;s seguro.
+
+<h2>Consejos</h2>
+<p>TODO</p>
+</ul>
+<h2>Notas</h2>
+<p>Este test establece la opci&oacute;n "Completar objetos individuales", quiz&aacute;s desee resetear la Configuraci&oacute;n de Impresi&oacute;n despu&eacute;s de imprimir el test.</p>
+<p>Licencia de los modelos usados en este test de calibraci&oacute;n: CC BY-SA 3.0</p>
+</body>
+</html>

--- a/resources/calibration/retraction/es_retraction.html
+++ b/resources/calibration/retraction/es_retraction.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Calibraci&oacute;n de Retracci&oacute;n</title>
+</head>
+<body>
+
+<table width="100%">
+<tbody>
+<tr>
+<td style="text-align: center;">
+<h1>Calibraci&oacute;n de Retracci&oacute;n</h1>
+</td>
+</tr>
+<tr>
+<td style="text-align: right;"><strong>
+    <table><tr><td>Necesitas:</td>
+        <td style="text-align: left;">Flujo</td>
+        <td style="text-align: left;">Temperatura</td></tr>
+    </table>
+    </strong>
+</tr>
+</tbody>
+</table>
+
+<h2>C&oacute;mo realizarlo</h2>
+<p>Es preferible haber realizado las calibraciones de flujo y temperatura.
+Esta calibraci&oacute;n le ayudar&aacute; a elegir los valores correctos de distancia de retracci&oacute;n para su extrusor y el filamento actual</p>
+<p>Este test imprimir&aacute; una pieza varianado la distancia de retracci&oacute;n para cada mil&iacute;metro impreso en el eje Z.</p>
+<h3>Incrementos y Altura</h3>
+<p> Si tiene extrusi&oacute;n directa, es mejor probar con incrementos de 0.1 mm (Steps) y ~15 mm de Altura, ya que no es com&uacute;n necesitar m&aacute;s de 1 mm de retracci&oacute;n.</h2>
+<p> Si tiene extrusi&oacute;n Bowden, es mejor probar con incrementos de 0.5 mm Steps) y ~15 mm de Altura, ya que no es com&uacute;n necesitar m&aacute;s de 6 mm de retracci&oacute;n. Tambi&eacute;n puede usar incrementos de 0.2 y una altura mayor. Tenga cuidado, ya que una alta distancia de retracci&oacute;n, incrementar&aacute; el riesgo de atasco en la boquilla si suele tenerlos.</h2>
+<h3>Temperatura de Inicio e Incrementos</h3>
+<p>Por defecto, usa la temperatura actual para un solo test. As&iacute; que no deber&iacute;a modificarla, a menos que tambi&eacute;n desee optimizar la temperatura para prevenir hilos (de una torre a otra, stringing).</p>
+<p>En la calibraci&oacute;n de temperatura, obtuvo un intervalo de temperatura donde su impresi&oacute;n fue "suficientemente buena".</p>
+<p>Aqu&iacute;, usted deber&iacute;a empezar en la m&aacute;s alta temperatura aceptable. Si ya estableci&oacute; la temperatura de su filamento, se tomar&aacute; ese valor como "actual" para la temperatura inicial (Start temp). Si no la ha establecido a&uacute;n, seleccione la mayor temperatura en el desplegable "Start temp".</p>
+<p>Despu&eacute;s, elija una opci&oacute;n en el campo "Temp decr" que no reduzca la temperatura demasiado bajo. "3x10" significa que imprimir&aacute; tres tests, el primer test a la max. temp. y el resto decrementando 10C en cada uno.</p>
+<h3>Modificando capas peque&ntilde;as</h3>
+Este bot&oacute;n cambiar&aacute; las configuraciones de Filamento/refrigeraci&oacute;n para deshabilitar todas las caracter&iacute;sticas que se activan cuando una capa es muy peque&ntilde;a y necesita enfriarse a tiempo. Con este algoritmo deshabilitado, a&ntilde;adimos un reto extra a su impresora en t&eacute;rminos de retracci&oacute;n, as&iacute; que es un buen test de estr&eacute;s. Para habilitar de nuevo esas opciones tras esta impresi&oacute;n, elimine las modificaciones hechas por este test en la pesta&ntilde;a de Filamento (la peque&ntilde;a "flecha hacia atr&aacute;s" en color naranja).
+<h3>Resultados</h3>
+<p> Terminada esta impresi&oacute;n, puede contar los mil&iacute;metros con los peque&ntilde;os salientes que tiene a los lados las torres. Yo los cuento con mi u&ntilde;a. Cuando est&eacute; en la altura donde ya no haya hilos (stringing) de una torre a otra, tome ese n&uacute;mero. Multiplique ese n&uacute;mero por los Incrementos elegidos (Steps  0.1, 0.2, 0.5, &oacute; 1) y ya tiene la distancia de retracci&oacute;n para modificar (Ajustes Avanzados, Configuraci&oacute;n de Impresora, Extrusor, Retracci&oacute;n -> Largo). Puede a&ntilde;adir un 20% m&aacute;s de distancia para tener un peque&ntilde;o margen.</p>
+<p>Si tiene varias impresiones con diferentes tempearaturas, necesita elegir la mejor impresi&oacute;n, aquella con menos hilos, a menos que el decremento de hilos no sea tan grande como para justificar el decremento de temperatura.
+<h2>Ejemplo</h2>
+<table width="100%">
+<tbody>
+<tr>
+<td><img src="./retraction.jpg" width="480" height="270" /></td>
+<td>En esta impresi&oacute;n, el &uacute;ltimo hilo ocurre a la altura de ~10. Como us&eacute; un salto de 0.5, significa que necesito al menos 5mm de retracci&oacute;n, pero lo establecer&eacute; en 6 para asegurarme de eliminar la mayor&iacute;a de hilos.</td>
+<td>
+</tr>
+</tbody>
+</table>
+<p> </p>
+<h2>Notas</h2>
+<p>La velocidad de retracci&oacute;n debe ser tan alta como su extrusor/controladores/drivers puedan soportar de forma segura, con cierto margen. 50mm/s para retracci&oacute;n y 20mm/s para de-retracci&oacute;n son buenos valores de partida para PLA.</p>
+<p>Licencia de los modelos usados en este test de calibraci&oacute;n: CC BY-SA 3.0</p>
+</body>
+</html>


### PR DESCRIPTION
Human translated Calibration HTML files to es_ES following rules from fr_*.html translated files.

I double checked all files are properly shown inside SuperSlicer with special spanish symbols.

All files are New files since there is no spanish translation yet.

Cheers!